### PR TITLE
fix: preserve CLI bins in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "./dist/core/index.js",
   "bin": {
-    "aeoptimize": "./dist/cli/index.js",
-    "aeo": "./dist/cli/index.js",
-    "aeo-cli": "./dist/cli/index.js"
+    "aeoptimize": "dist/cli/index.js",
+    "aeo": "dist/cli/index.js",
+    "aeo-cli": "dist/cli/index.js"
   },
   "exports": {
     ".": "./dist/core/index.js",
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/cucuwang/aeoptimize",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cucuwang/aeoptimize.git"
+    "url": "git+https://github.com/cucuwang/aeoptimize.git"
   },
   "bugs": {
     "url": "https://github.com/cucuwang/aeoptimize/issues"

--- a/src/core/__tests__/evidence-boundaries.test.ts
+++ b/src/core/__tests__/evidence-boundaries.test.ts
@@ -93,4 +93,15 @@ describe('public metadata', () => {
     expect(compatibilityAction).toContain(`default: 'aeoptimize@${packageJson.version}'`);
     expect(compatibilityAction).toContain("default: 'false'");
   });
+
+  it('keeps npm publisher metadata normalized and exposes every CLI alias', async () => {
+    const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+
+    expect(packageJson.repository.url).toBe('git+https://github.com/cucuwang/aeoptimize.git');
+    expect(packageJson.bin).toEqual({
+      aeoptimize: 'dist/cli/index.js',
+      aeo: 'dist/cli/index.js',
+      'aeo-cli': 'dist/cli/index.js',
+    });
+  });
 });


### PR DESCRIPTION
## What changed

- normalize the three npm `bin` paths so publisher metadata keeps `aeoptimize`, `aeo`, and `aeo-cli`
- normalize the repository URL to npm's canonical Git URL
- add a regression test for the published CLI aliases and repository metadata

## Why

With npm 11.17.0, `npm publish --dry-run` removed the previous `./dist/cli/index.js` bin entries as invalid. Publishing that manifest would install the package without its documented CLI commands and would also break the v0.6.0 GitHub Action.

## User impact

The packed package now retains all three CLI aliases. A clean tarball installation can invoke each alias and receives version `0.6.0`.

## Validation

- `npm run check`: 60 tests passed and TypeScript build completed
- `npm publish --dry-run --json`: completed without publisher metadata corrections
- packed `package.json`: all three bin entries retained
- isolated tarball install: `aeoptimize --version`, `aeo --version`, and `aeo-cli --version` each returned `0.6.0`

This PR does not create a tag, publish a GitHub Release, or publish to npm.
