### PR TITLE
Prepare v0.6.3 Marketplace release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Content-readiness lint with evidence-bounded AI discovery experiments",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aeoptimize",
   "description": "Content-readiness lint and evidence-bounded discovery experiments",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "Te-Shu Wang"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           path: .github/fixtures/action-low
           min-score: '100'
-          package-spec: ./aeoptimize-0.6.2.tgz
+          package-spec: ./aeoptimize-0.6.3.tgz
 
       - name: Validate Action outputs
         env:
@@ -101,7 +101,7 @@ jobs:
         uses: ./
         with:
           path: examples/github-action-sample/site
-          package-spec: ./aeoptimize-0.6.2.tgz
+          package-spec: ./aeoptimize-0.6.3.tgz
 
       - name: Validate sample outputs
         env:
@@ -120,7 +120,7 @@ jobs:
           path: .github/fixtures/action-low
           min-score: '0'
           fail-on-low-score: 'true'
-          package-spec: ./aeoptimize-0.6.2.tgz
+          package-spec: ./aeoptimize-0.6.3.tgz
 
       - name: Validate blocking outputs
         env:
@@ -140,7 +140,7 @@ jobs:
           path: .github/fixtures/action-low
           min-score: '100'
           fail-on-low-score: 'true'
-          package-spec: ./aeoptimize-0.6.2.tgz
+          package-spec: ./aeoptimize-0.6.3.tgz
 
       - name: Invalid choice is rejected
         id: invalid-choice
@@ -149,7 +149,7 @@ jobs:
         with:
           path: .github/fixtures/action-low
           fail-on-low-score: sometimes
-          package-spec: ./aeoptimize-0.6.2.tgz
+          package-spec: ./aeoptimize-0.6.3.tgz
 
       - name: Out-of-range threshold is rejected
         id: invalid-threshold
@@ -158,7 +158,7 @@ jobs:
         with:
           path: .github/fixtures/action-low
           min-score: '101'
-          package-spec: ./aeoptimize-0.6.2.tgz
+          package-spec: ./aeoptimize-0.6.3.tgz
 
       - name: Assert expected failures
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-visible changes will be documented here. The project follows Semantic Versioning after the v0.6 evidence baseline is released.
 
+## 0.6.3
+
+### Changed
+
+- Added a concise install path, terminal demo, comparison table, and first-contribution guidance to the public documentation.
+- Documented immutable Action pins and cross-agent skill discovery.
+- Prepared the existing root composite Action for its first GitHub Marketplace release without changing scoring, runtime behavior, inputs, or outputs.
+
 ## 0.6.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ npx aeoptimize scan ./dist --dir --json > aeoptimize-report.json
 node -e "const r=require('./aeoptimize-report.json'); process.exit(r.overall.total < 60 ? 1 : 0)"
 ```
 
-The v0.6 GitHub Action is advisory by default. Consume it from the repository pin until it appears on GitHub Marketplace (Marketplace listing is a checkbox on a GitHub Release, not an extra package). It reports findings without blocking the workflow:
+The v0.6 GitHub Action is advisory by default. Consume it from the immutable repository pin; the v0.6.3 release is prepared for the first GitHub Marketplace listing. It reports findings without blocking the workflow:
 
 ```yaml
-- uses: cucuwang/aeoptimize@v0.6.2
+- uses: cucuwang/aeoptimize@v0.6.3
   with:
     path: dist
 ```
@@ -90,7 +90,7 @@ The v0.6 GitHub Action is advisory by default. Consume it from the repository pi
 Projects can explicitly choose blocking mode after accepting a baseline:
 
 ```yaml
-- uses: cucuwang/aeoptimize@v0.6.2
+- uses: cucuwang/aeoptimize@v0.6.3
   with:
     path: dist
     fail-on-low-score: 'true'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   package-spec:
     description: npm package spec to install; keep the default outside prerelease testing
     required: false
-    default: 'aeoptimize@0.6.2'
+    default: 'aeoptimize@0.6.3'
 
 outputs:
   score:

--- a/action/action.yml
+++ b/action/action.yml
@@ -20,7 +20,7 @@ inputs:
   package-spec:
     description: npm package spec to install; keep the default outside prerelease testing
     required: false
-    default: 'aeoptimize@0.6.2'
+    default: 'aeoptimize@0.6.3'
 
 outputs:
   score:

--- a/docs/release-v0.6.md
+++ b/docs/release-v0.6.md
@@ -1,6 +1,6 @@
 # v0.6 release and rollback guide
 
-Version 0.6.2 is the provenance-corrective release for the v0.6 evidence-bounded scoring, packaging, and GitHub Action contracts. npm 0.6.1 contained the verified candidate bytes but exposed the pre-squash PR commit as `gitHead`, so no v0.6.1 Git tag or GitHub Release was created. Version 0.6.2 is not released until npm, the Git tag, and the GitHub Release are each created and read back independently.
+Version 0.6.3 packages the documentation improvements made after the v0.6.2 provenance correction and prepares the existing root composite Action for its first GitHub Marketplace listing. It does not change scoring rules, runtime behavior, Action inputs, or Action outputs. Version 0.6.3 is not released until npm, the Git tag, the GitHub Release, and the Marketplace listing are each created and read back independently.
 
 ## Release acceptance
 
@@ -16,6 +16,8 @@ Before publication, run `npm ci` and `npm run release:check` from the intended r
 CI runs the same candidate gate on Node.js 22 and 24 and compares version, filename, SHA-256, file count, and unpacked size. `prepublishOnly` invokes the candidate gate again, refuses a dirty worktree, and refuses publication unless `HEAD` matches `origin/main` exactly. Run `git fetch origin main` immediately before the authorized publish so the remote-tracking ref is current.
 
 Publishing, tagging, creating a GitHub Release, changing npm dist-tags, and deprecating a version are separate external mutations and require separate maintainer authorization.
+
+Marketplace publication also requires a browser release flow. Confirm that the public repository has one root `action.yml`, the Action name is accepted as unique, the Marketplace Developer Agreement is accepted, and the release page reports that the metadata is valid. Select an accurate primary category and enable **Publish this Action to the GitHub Marketplace** before publishing the release. The final release submission requires maintainer-controlled two-factor authentication.
 
 ## Release notes
 
@@ -36,16 +38,16 @@ After an authorized npm publication:
 
 ```bash
 npm view aeoptimize version dist-tags --json
-npm view aeoptimize@0.6.2 version gitHead repository homepage bugs dist --json
-consumer_root=$(mktemp -d "${TMPDIR:-/tmp}/aeoptimize-v0.6.2-consumer.XXXXXX")
-npm install --prefix "$consumer_root" aeoptimize@0.6.2
+npm view aeoptimize@0.6.3 version gitHead repository homepage bugs dist --json
+consumer_root=$(mktemp -d "${TMPDIR:-/tmp}/aeoptimize-v0.6.3-consumer.XXXXXX")
+npm install --prefix "$consumer_root" aeoptimize@0.6.3
 "$consumer_root/node_modules/.bin/aeoptimize" --version
 "$consumer_root/node_modules/.bin/aeo" --version
 "$consumer_root/node_modules/.bin/aeo-cli" --version
 rm -rf -- "$consumer_root"
 ```
 
-After separately authorized tag and GitHub Release creation, verify that `v0.6.2` points to the tested release commit and that the Release is published rather than draft or prerelease.
+After separately authorized tag and GitHub Release creation, verify that `v0.6.3` points to the tested release commit, that the Release is published rather than draft or prerelease, and that the release appears on GitHub Marketplace.
 
 The fail-closed public verifier checks npm `latest`, the exact version, public repository identity, the downloaded tarball SHA-256, all three installed CLI aliases, the tag target, and the published GitHub Release. The tarball hash is the required artifact-identity gate. If npm exposes `gitHead`, it must match the expected release commit; absence is reported as informational because npm's publish contract guarantees tarball integrity but does not guarantee that metadata field.
 
@@ -57,11 +59,11 @@ bash scripts/verify-release-v0.6.sh <verified-release-commit> <verified-package-
 
 An npm dist-tag rollback changes what `npm install aeoptimize` selects; it does not remove exact-version installs. Never silently move an existing Git tag to different code.
 
-If npm 0.6.2 is unsuitable, request separate authorization for each mutation and restore `latest` to the last fully released version rather than the provenance-mismatched 0.6.1 artifact:
+If npm 0.6.3 is unsuitable, request separate authorization for each mutation and restore `latest` to the last fully released version:
 
 ```bash
-npm dist-tag add aeoptimize@0.6.0 latest
-npm deprecate aeoptimize@0.6.2 "Use 0.6.0 until the corrective release is available."
+npm dist-tag add aeoptimize@0.6.2 latest
+npm deprecate aeoptimize@0.6.3 "Use 0.6.2 while the corrective release is prepared."
 ```
 
-Mark the GitHub Release with the same warning. Never create or retarget `v0.6.1` merely to mask its npm `gitHead` mismatch. Preserve immutable versions as evidence, fix forward in 0.6.3, rerun the complete release acceptance suite, and only then move npm `latest` to the corrective version.
+Mark the GitHub Release and Marketplace listing with the same warning. Never create or retarget `v0.6.1` merely to mask its npm `gitHead` mismatch. Preserve immutable versions as evidence, prepare a new patch release, rerun the complete release acceptance suite, and only then move npm `latest` to the corrective version.

--- a/examples/github-action-sample/.github/workflows/aeoptimize.yml
+++ b/examples/github-action-sample/.github/workflows/aeoptimize.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cucuwang/aeoptimize@v0.6.2
+      - uses: cucuwang/aeoptimize@v0.6.3
         with:
           path: site
           fail-on-low-score: 'false'

--- a/examples/github-action-sample/README.md
+++ b/examples/github-action-sample/README.md
@@ -6,4 +6,4 @@ This directory is a copyable end-to-end sample for the v0.6 Action contract.
 - `site/index.html` is a deterministic public input.
 - The Action is advisory by default. The sample does not block a pull request on an unreviewed score threshold.
 
-The workflow becomes reproducible only after both `aeoptimize@0.6.2` exists on npm and the immutable `v0.6.2` Git tag points to the matching release commit. Until both artifacts exist, use the local CLI or the release-candidate package during controlled verification.
+The workflow becomes reproducible only after both `aeoptimize@0.6.3` exists on npm and the immutable `v0.6.3` Git tag points to the matching release commit. Until both artifacts exist, use the local CLI or the release-candidate package during controlled verification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aeoptimize",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aeoptimize",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeoptimize",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Deterministic content-readiness lint for static websites and documentation",
   "type": "module",
   "main": "./dist/core/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,7 +18,7 @@ const program = new Command();
 program
   .name('aeoptimize')
   .description('Deterministic content-readiness lint for websites and documentation')
-  .version('0.6.2');
+  .version('0.6.3');
 
 // ── scan command ───────────────────────────────────────────────────
 

--- a/src/core/__tests__/evidence-boundaries.test.ts
+++ b/src/core/__tests__/evidence-boundaries.test.ts
@@ -83,7 +83,7 @@ describe('public metadata', () => {
     const action = await readFile(join(root, 'action.yml'), 'utf8');
     const compatibilityAction = await readFile(join(root, 'action/action.yml'), 'utf8');
 
-    expect(packageJson.version).toBe('0.6.2');
+    expect(packageJson.version).toBe('0.6.3');
     expect(pluginJson.version).toBe(packageJson.version);
     expect(marketplaceJson.metadata.version).toBe(packageJson.version);
     expect(cli).toContain(`.version('${packageJson.version}')`);

--- a/src/core/__tests__/release-contract.test.ts
+++ b/src/core/__tests__/release-contract.test.ts
@@ -192,7 +192,7 @@ describe('v0.6 JSON automation contract', () => {
       'npm run release:check && bash scripts/verify-publish-source.sh',
     );
     expect(releaseGuide).toContain('## Rollback');
-    expect(releaseGuide).toContain('npm dist-tag add aeoptimize@0.6.0 latest');
+    expect(releaseGuide).toContain('npm dist-tag add aeoptimize@0.6.2 latest');
     expect(releaseGuide).toContain('<verified-package-sha256>');
     expect(publicVerifier).toContain('.gitHead');
     expect(publicVerifier).toContain('EXPECTED_REPOSITORY_URL');

--- a/src/core/__tests__/release-verifier.test.ts
+++ b/src/core/__tests__/release-verifier.test.ts
@@ -10,7 +10,7 @@ const testDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = join(testDirectory, '../../..');
 const verifier = join(repositoryRoot, 'scripts/verify-release-v0.6.sh');
 const expectedCommit = '0123456789abcdef0123456789abcdef01234567';
-const tarballContent = 'verified aeoptimize v0.6.2 candidate';
+const tarballContent = 'verified aeoptimize v0.6.3 candidate';
 const expectedTarballHash = createHash('sha256').update(tarballContent).digest('hex');
 
 interface CommandResult {
@@ -29,7 +29,7 @@ function runVerifier(
       env: {
         ...process.env,
         PATH: `${mockBin}:${process.env.PATH}`,
-        MOCK_LATEST: '0.6.2',
+        MOCK_LATEST: '0.6.3',
         MOCK_NPM_GIT_HEAD: expectedCommit,
         MOCK_REPOSITORY_URL: 'git+https://github.com/cucuwang/aeoptimize.git',
         MOCK_TAG_COMMIT: expectedCommit,
@@ -80,13 +80,13 @@ done
 
 case "$url" in
   https://registry.npmjs.org/aeoptimize)
-    printf '{"dist-tags":{"latest":"%s"},"versions":{"0.6.2":{"gitHead":"%s","repository":{"url":"%s"},"homepage":"https://github.com/cucuwang/aeoptimize","bugs":{"url":"https://github.com/cucuwang/aeoptimize/issues"},"dist":{"tarball":"https://registry.npmjs.org/aeoptimize/-/aeoptimize-0.6.2.tgz"}}}}' "$MOCK_LATEST" "$MOCK_NPM_GIT_HEAD" "$MOCK_REPOSITORY_URL"
+    printf '{"dist-tags":{"latest":"%s"},"versions":{"0.6.3":{"gitHead":"%s","repository":{"url":"%s"},"homepage":"https://github.com/cucuwang/aeoptimize","bugs":{"url":"https://github.com/cucuwang/aeoptimize/issues"},"dist":{"tarball":"https://registry.npmjs.org/aeoptimize/-/aeoptimize-0.6.3.tgz"}}}}' "$MOCK_LATEST" "$MOCK_NPM_GIT_HEAD" "$MOCK_REPOSITORY_URL"
     ;;
-  https://registry.npmjs.org/aeoptimize/-/aeoptimize-0.6.2.tgz)
+  https://registry.npmjs.org/aeoptimize/-/aeoptimize-0.6.3.tgz)
     printf '%s' "$MOCK_TARBALL_CONTENT" > "$output_file"
     ;;
-  https://api.github.com/repos/cucuwang/aeoptimize/releases/tags/v0.6.2)
-    printf '{"tag_name":"v0.6.2","draft":%s,"prerelease":%s}' "$MOCK_RELEASE_DRAFT" "$MOCK_RELEASE_PRERELEASE" > "$output_file"
+  https://api.github.com/repos/cucuwang/aeoptimize/releases/tags/v0.6.3)
+    printf '{"tag_name":"v0.6.3","draft":%s,"prerelease":%s}' "$MOCK_RELEASE_DRAFT" "$MOCK_RELEASE_PRERELEASE" > "$output_file"
     printf '200'
     ;;
   *)
@@ -98,7 +98,7 @@ esac
 
     await writeExecutable(join(mockBin, 'git'), `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\trefs/tags/v0.6.2\n' "$MOCK_TAG_COMMIT"
+printf '%s\trefs/tags/v0.6.3\n' "$MOCK_TAG_COMMIT"
 `);
 
     await writeExecutable(join(mockBin, 'npm'), `#!/usr/bin/env bash
@@ -116,7 +116,7 @@ for binary in aeoptimize aeo aeo-cli; do
   if [ "$binary" = "$MOCK_MISSING_BINARY" ]; then
     continue
   fi
-  printf '#!/usr/bin/env bash\nprintf "0.6.2\\n"\n' > "$prefix/node_modules/.bin/$binary"
+  printf '#!/usr/bin/env bash\nprintf "0.6.3\\n"\n' > "$prefix/node_modules/.bin/$binary"
   chmod +x "$prefix/node_modules/.bin/$binary"
 done
 `);
@@ -135,8 +135,8 @@ done
     expect(result.stdout).toContain('PASS: npm gitHead matches');
     expect(result.stdout).toContain('PASS: npm tarball SHA-256 matches the verified candidate');
     expect(result.stdout).toContain('All public release checks passed.');
-    expect(npmArgs).toMatch(/aeoptimize-0\.6\.2\.tgz/);
-    expect(npmArgs).not.toContain('aeoptimize@0.6.2');
+    expect(npmArgs).toMatch(/aeoptimize-0\.6\.3\.tgz/);
+    expect(npmArgs).not.toContain('aeoptimize@0.6.3');
   });
 
   it('fails closed when npm serves a different tarball', async () => {
@@ -177,7 +177,7 @@ done
     });
 
     expect(result.code).toBe(1);
-    expect(result.stderr).toContain('FAIL: v0.6.2 points to');
+    expect(result.stderr).toContain('FAIL: v0.6.3 points to');
   });
 
   it('fails closed when the GitHub Release is a draft', async () => {


### PR DESCRIPTION
## Summary
Prepare v0.6.3 as a documentation and distribution patch for the Action's first GitHub Marketplace release. Align package, CLI, plugin, Action, CI, sample, verifier, and rollback metadata without changing scoring, runtime behavior, Action inputs, or outputs.

## Testing
- `npm run release:check`
- 159 tests passed
- TypeScript build passed
- Action contract passed
- npm audit reported 0 vulnerabilities
- candidate SHA-256: `81f36252fc0fdb5128ace7c1fda96d9e04648aec5a8e6cb318097029f67169ac`

No tag, npm publication, GitHub Release, or Marketplace listing has been created.

## For reviewers
Please verify that all v0.6.3 references are aligned and rollback selects v0.6.2.
