### PR TITLE
Harden release trust, CI and supply-chain evidence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Routing only: do not require self-approval in the single-maintainer ruleset.
+/.github/ @cucuwang
+/action.yml @cucuwang
+/action/ @cucuwang
+/package.json @cucuwang
+/package-lock.json @cucuwang
+/scripts/verify-* @cucuwang
+/scripts/*release* @cucuwang
+/SECURITY.md @cucuwang

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: A reproducible failure or regression
+---
+
+## Expected and actual behavior
+
+## Reproduction
+
+Include geoptimize/Node versions, OS, command and a minimal public fixture.
+Remove credentials, private URLs and personal content.
+
+## Output
+
+For vulnerabilities, follow SECURITY.md instead of posting exploit details here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security reporting policy
+    url: https://github.com/cucuwang/geoptimize/blob/main/SECURITY.md
+    about: Read the private reporting process before sharing vulnerability details.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Describe a concrete workflow and measurable benefit
+---
+
+## Workflow and problem
+
+## Proposed behavior and acceptance example
+
+## Compatibility or methodology impact

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      development:
+        dependency-type: development
+        update-types: [minor, patch]
+      production:
+        dependency-type: production
+        update-types: [minor, patch]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Problem and change
+
+Describe the problem, resulting behavior and scope.
+
+## Validation and impact
+
+- [ ] Tests/build pass; include commands and results.
+- [ ] CLI, API, JSON and Action contracts preserved or changes documented.
+- [ ] Security and dependency impact reviewed.
+- [ ] Scoring/methodology impact stated; rule changes include evidence and fixtures.
+- [ ] Documentation and changelog updated where relevant.
+- [ ] Release/package impact and maintainer steps stated.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           mv "$RUNNER_TEMP/release-assets/geoptimize-24.tgz" "$RUNNER_TEMP/release-assets/geoptimize-$version.tgz"
           node scripts/prepare-release-artifacts.mjs "$RUNNER_TEMP/release-assets"
           (cd "$RUNNER_TEMP/release-assets" && sha256sum --check SHA256SUMS)
-          npm publish "$RUNNER_TEMP/release-assets/geoptimize-$version.tgz" --dry-run --ignore-scripts --access public
+          npm pack "$RUNNER_TEMP/release-assets/geoptimize-$version.tgz" --dry-run --ignore-scripts --json > "$RUNNER_TEMP/release-assets/package-preview.json"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: matrix.node-version == 24
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
+  workflow_call:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   test-and-build:
@@ -14,25 +18,46 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - name: Prepare candidate directory
+        run: mkdir -p "$RUNNER_TEMP/release-assets"
       - run: npm run release:check
         env:
+          RELEASE_TARBALL_OUT: ${{ runner.temp }}/release-assets/geoptimize-${{ matrix.node-version }}.tgz
           RELEASE_MANIFEST_OUT: ${{ runner.temp }}/release-candidate-node-${{ matrix.node-version }}.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-candidate-node-${{ matrix.node-version }}
           path: ${{ runner.temp }}/release-candidate-node-${{ matrix.node-version }}.json
+          if-no-files-found: error
+
+      - name: Prepare release artifacts and exercise non-publishing path
+        if: matrix.node-version == 24
+        run: |
+          version=$(node -p "JSON.parse(require('fs').readFileSync('package.json')).version")
+          cp "$RUNNER_TEMP/release-candidate-node-24.json" "$RUNNER_TEMP/release-assets/candidate.json"
+          mv "$RUNNER_TEMP/release-assets/geoptimize-24.tgz" "$RUNNER_TEMP/release-assets/geoptimize-$version.tgz"
+          node scripts/prepare-release-artifacts.mjs "$RUNNER_TEMP/release-assets"
+          (cd "$RUNNER_TEMP/release-assets" && sha256sum --check SHA256SUMS)
+          npm publish "$RUNNER_TEMP/release-assets/geoptimize-$version.tgz" --dry-run --ignore-scripts --access public
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: matrix.node-version == 24
+        with:
+          name: release-assets
+          path: ${{ runner.temp }}/release-assets/
           if-no-files-found: error
 
   release-candidate-reproducibility:
     needs: test-and-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: release-candidate-node-*
           path: release-candidates
@@ -56,8 +81,10 @@ jobs:
   lint-readme-commands:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
       - run: npm ci
@@ -70,8 +97,10 @@ jobs:
   action-contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
       - run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 3 * * 1'
+permissions:
+  contents: read
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3 (2026-09-09)
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3 (2026-09-09)
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency Review
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the verified candidate (requires completed maintainer checklist)
+        type: boolean
+        default: false
+      tag:
+        description: Existing signed release tag; required only for publication
+        type: string
+        default: ''
+permissions:
+  contents: read
+concurrency:
+  group: geoptimize-release
+  cancel-in-progress: false
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject an unauthorized publication request
+        if: inputs.publish
+        env:
+          ENABLED: ${{ vars.RELEASE_ENABLED }}
+          REF: ${{ github.ref }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          test "$ENABLED" = true
+          test "$REF" = refs/heads/main
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+  validate:
+    needs: request
+    uses: ./.github/workflows/ci.yml
+  publish:
+    needs: validate
+    if: inputs.publish && github.ref == 'refs/heads/main' && vars.RELEASE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-assets
+          path: ${{ runner.temp }}/release-assets
+      - name: Verify source, signed tag, candidate and unpublished version
+        run: bash scripts/verify-release-publication.sh "$RUNNER_TEMP/release-assets"
+      - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: ${{ runner.temp }}/release-assets/geoptimize-*.tgz
+      - name: Stage all assets in a draft release
+        run: |
+          gh release create "$RELEASE_TAG" --verify-tag --draft --title "geoptimize ${RELEASE_TAG#v}" --notes-file docs/release-v0.10.md
+          gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/release-assets/"*.tgz "$RUNNER_TEMP/release-assets/SHA256SUMS" "$RUNNER_TEMP/release-assets/"*.spdx.json
+      - name: Publish the verified tarball using npm OIDC
+        run: |
+          # Recheck main immediately before the irreversible operation.
+          test "$(gh api repos/cucuwang/geoptimize/git/ref/heads/main --jq .object.sha)" = "$GITHUB_SHA"
+          (cd "$RUNNER_TEMP/release-assets" && sha256sum --check SHA256SUMS)
+          npm publish "$RUNNER_TEMP/release-assets/geoptimize-${RELEASE_TAG#v}.tgz" --access public --provenance --ignore-scripts
+      - name: Finalize the fully populated release
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest
+      - name: Verify public npm, GitHub and tag alignment
+        run: |
+          sha=$(jq -r .sha256 "$RUNNER_TEMP/release-assets/candidate.json")
+          bash scripts/verify-release-v0.8.sh "$GITHUB_SHA" "$sha"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           subject-path: ${{ runner.temp }}/release-assets/geoptimize-*.tgz
       - name: Stage all assets in a draft release
         run: |
-          gh release create "$RELEASE_TAG" --verify-tag --draft --title "geoptimize ${RELEASE_TAG#v}" --notes-file docs/release-v0.10.md
+          gh release create "$RELEASE_TAG" --verify-tag --draft --title "geoptimize ${RELEASE_TAG#v}" --notes-file docs/release-notes-v0.10.md
           gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/release-assets/"*.tgz "$RUNNER_TEMP/release-assets/SHA256SUMS" "$RUNNER_TEMP/release-assets/"*.spdx.json
       - name: Publish the verified tarball using npm OIDC
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,33 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '42 3 * * 1'
+permissions:
+  contents: read
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scorecard-results
+          path: results.sarif
+          if-no-files-found: error
+          retention-days: 14
+      - uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3 (2026-09-09)
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased — trust hardening
+
+- Prepare a SHA-pinned, least-privilege CI/security and OIDC release pipeline.
+- Export verified tarballs with checksums, SPDX SBOM and attestation support.
+- Document maintainer settings and OpenSSF gaps; preserve scoring and public contracts.
+
 All notable user-visible changes will be documented here. The project follows Semantic Versioning after the v0.6 evidence baseline is released.
 
 ## 0.9.0

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Projects can explicitly choose blocking mode after accepting a baseline:
     min-score: '60'
 ```
 
-The Action exposes `score` and `report` outputs in both modes. Its release is reproducible only when the Action tag and matching npm package version both exist. Before pinning a version, verify both artifacts; if either is missing, use the CLI directly.
+The Action exposes `score` and `report` outputs in both modes. Its default selects an exact npm package version; transitive dependencies are resolved at install time. Verify the Action tag and matching npm package before pinning. See the [Action reproducibility decision](docs/action-reproducibility.md) for the remaining dependency-resolution boundary.
 
 A copyable advisory workflow and controlled input are available in the [end-to-end Action sample](examples/github-action-sample/README.md).
 
@@ -320,6 +320,15 @@ npx skills add cucuwang/geoptimize
 Version 0.9 adds site metrics, offline visual reports, detailed rule evidence and baseline comparisons while retaining the existing scoring contract. Release acceptance and rollback are documented in [docs/release-v0.9.md](docs/release-v0.9.md); longer-term adoption work remains in [ROADMAP.md](ROADMAP.md).
 
 Contributions are welcome. Rule changes require an evidence note and positive/negative fixtures; see [CONTRIBUTING.md](CONTRIBUTING.md). Report vulnerabilities through the process in [SECURITY.md](SECURITY.md).
+
+## Release integrity and security maintenance
+
+The next-release trust-hardening path is documented in [the v0.10 runbook](docs/release-v0.10.md).
+CI validates Node 22/24 tarballs, package contents and CLI/Action contracts; the
+release preparation exports SHA-256 checksums and an SPDX production-dependency SBOM.
+Repository settings and npm authorization remain explicit [maintainer gates](docs/maintainer-security-settings.md).
+[OpenSSF Passing preparation](docs/openssf-best-practices.md) records outstanding
+verification. Scorecard/Best Practices badges will be added only after real results exist.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,3 +29,13 @@ The code-level gates are enforced by `npm run release:check`, `src/core/__tests_
 - awarding points for `llms.txt`, FAQ count, schema count, or a fixed meta-description length;
 - automatic deployment of generated JSON-LD or crawler policy;
 - adding more AI scorers and calling their average consensus.
+
+## v0.10 — Trust hardening
+
+Repository preparation covers SHA-pinned Actions, minimal token permissions, a
+reusable release pipeline, OIDC preparation, tarball hashes/SPDX/attestations,
+dependency review, CodeQL, Dependabot, Scorecard and maintainer governance guidance.
+Account settings, signing identity and actual publication are separate gates;
+OpenSSF Passing is pending assessment. Package version remains 0.9.0 until release
+approval. Bundled Action runtime evaluation is tracked separately to preserve the
+package-spec contract. See [release-v0.10](docs/release-v0.10.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,14 @@ Include the affected version, environment, reproduction preconditions, impact, a
 ## Scope notes
 
 `geoptimize` can fetch remote pages, invoke a local browser, read build output, and install a Git hook. Reports may contain URLs and excerpts from scanned content. Review artifacts before publishing them and never scan private systems without authorization.
+
+## Release and dependency integrity
+
+Release candidates retain the high/critical npm audit gate. Pull requests add
+dependency review; weekly Dependabot and CodeQL/Scorecard workflows support ongoing
+triage. Configuration alone does not establish a clean scan or certification.
+
+The next automated release uses npm OIDC, tarball attestations, checksums and a locked
+production SBOM. Follow [release verification](docs/release-v0.10.md) and
+[maintainer security settings](docs/maintainer-security-settings.md). Existing releases
+are not retroactively signed or attested. No long-lived npm credential is required.

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24'
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24'
 

--- a/docs/action-pins.md
+++ b/docs/action-pins.md
@@ -1,0 +1,27 @@
+# Verified upstream Action pins
+
+Resolved through official GitHub repositories on 2026-09-09. Annotated tag objects
+were dereferenced to commits; tag-object SHAs are not used as Action pins.
+
+| Action | Upstream tag | Full commit |
+| --- | --- | --- |
+| actions/checkout | v4.3.0 | 08eba0b27e820071cde6df949e0beb9ba4906955 |
+| actions/setup-node | v4.4.0 | 49933ea5288caeca8642d1e84afbd3f7d6820020 |
+| actions/upload-artifact | v4.6.2 | ea165f8d65b6e75b540449e92b4886f43607fa02 |
+| actions/download-artifact | v4.3.0 | d3f86a106a0bac45b974a628896c90dbdf5c8093 |
+| actions/dependency-review-action | v5.0.0 | a1d282b36b6f3519aa1f3fc636f609c47dddb294 |
+| github/codeql-action | v3, resolved on assessment date | 6f5948dfacef28e207b48d0905cf90c03365536d |
+| ossf/scorecard-action | v2.4.3 | 4eaacf0543bb3f2c246792bd56e8cdeffafb205a |
+| actions/attest-build-provenance | v3, resolved on assessment date | 977bb373ede98d70efdf65b84cb5f73e068dcc2a |
+
+Recheck with `GET /repos/{owner}/{repo}/git/ref/tags/{tag}`. When object.type is
+`tag`, follow object.url until object.type is `commit`. Cross-check the official
+release notes before accepting a Dependabot update. A mutable major tag is only the
+lookup source; the workflow itself always executes the recorded full commit.
+
+Permissions: ordinary CI/readme/contracts/release validation use contents:read.
+CodeQL adds security-events:write. Scorecard adds security-events:write and
+id-token:write for public result publication. Only the gated publication job adds
+contents:write (draft/assets/finalization), id-token:write (OIDC) and
+attestations:write. Checkout never persists credentials. No pull_request_target or
+write-token job executes PR code.

--- a/docs/action-reproducibility.md
+++ b/docs/action-reproducibility.md
@@ -1,0 +1,27 @@
+# Action reproducibility decision
+
+Decision: retain the composite Action for this PR; evaluate a bundle separately.
+Both Action metadata paths now pin setup-node to an upstream commit. The default
+package-spec remains the exact published geoptimize version. No runtime behavior
+or package-spec override has been removed.
+
+| Dimension | A: runtime npm install | B: checked-in bundled JS |
+| --- | --- | --- |
+| Reproducibility | Top-level version fixed; transitive semver resolution varies. A dedicated action lock and isolated npm ci could improve this. | Fixed dependency bytes with Action commit; needs reproducible bundle verification. |
+| Package size | Small checkout; dependency downloads on each fresh runner. | Larger repository artifact; quantify a prototype before choosing. |
+| Maintenance | Existing release and package-spec testing paths. Dedicated lock adds synchronization work. | Bundler, license notices, build verification and binary/runtime compatibility checks. |
+| Updates | npm version release; transitive resolution may change independently. | Every dependency update needs a rebuilt, reviewed bundle and new Action release. |
+| Security surface | Registry and install lifecycle scripts on every run. | Removes most install-time resolution; bundled vulnerabilities persist until updated. |
+| Marketplace | Current composite Action already works. | JavaScript Actions are supported; Node runtime and inputs/outputs need revalidation. |
+
+The public `package-spec` input deliberately permits test tarballs/alternate specs.
+Always running a fixed bundle would ignore that input; retaining an installer fallback
+preserves much of the current surface. Puppeteer-core/browser paths, ESM dependencies,
+and dynamic imports need bundle testing even though the Action's normal scan is local.
+A broad runtime rewrite is outside this security PR.
+
+Follow-up acceptance: prototype size and cold-run timing; build the bundle twice from
+npm ci and compare hashes; preserve both metadata paths, package-spec semantics,
+advisory/blocking behavior and outputs; inspect included licenses and optional browser
+code; add a stale-bundle CI check and an explicit dependency update workflow. Do not
+claim Option A has a fully locked consumer dependency tree.

--- a/docs/action-reproducibility.md
+++ b/docs/action-reproducibility.md
@@ -1,6 +1,6 @@
 # Action reproducibility decision
 
-Decision: retain the composite Action for this PR; evaluate a bundle separately.
+Decision: retain the composite Action for this PR; evaluate a bundle separately in [issue #20](https://github.com/cucuwang/geoptimize/issues/20).
 Both Action metadata paths now pin setup-node to an upstream commit. The default
 package-spec remains the exact published geoptimize version. No runtime behavior
 or package-spec override has been removed.

--- a/docs/maintainer-security-settings.md
+++ b/docs/maintainer-security-settings.md
@@ -1,17 +1,17 @@
 # Maintainer security settings
 
 Snapshot: 2026-09-09. Configuration files do not prove account settings are enabled.
-The connected API exposes ruleset reads, but no supported administration mutation.
-No account settings, credentials, production tags or releases were changed by this PR.
+The states below were read back through the repository administration API after an
+authorized settings update. No credentials, production tags or releases were changed.
 
 ## GitHub rulesets
 
 Settings → Rules → Rulesets → `protect-main` (ID 22617494) currently blocks deletion
 and force pushes only. It also targets two maintenance branches. Preserve that
-coverage; create a separate **main-required-checks** branch ruleset targeting `main`
-to avoid requiring new checks on historical maintenance branches.
+coverage. `main-required-checks` (ID 22637595) is Active with no bypass actors and
+targets the default branch without affecting historical maintenance branches.
 
-Set enforcement Active, no routine bypass actors, and enable:
+It enforces:
 
 - Require a pull request before merging; required approvals **0** for the current
   single maintainer. Leave required CODEOWNER review and last-push approval off.
@@ -19,7 +19,7 @@ Set enforcement Active, no routine bypass actors, and enable:
 - Require status checks to pass; require branches to be up to date before merging.
 - Block deletions and force pushes (already provided by protect-main).
 
-After the PR checks have run, choose these exact GitHub Actions contexts:
+These exact GitHub Actions contexts are required:
 
 | Required context | Source |
 | --- | --- |
@@ -32,10 +32,9 @@ After the PR checks have run, choose these exact GitHub Actions contexts:
 | `CodeQL (javascript-typescript)` | CodeQL |
 | `CodeQL (actions)` | CodeQL |
 
-The first five job identifiers and Node matrix values are preserved. Select the
-observed context names in Settings after successful runs; do not select the nested
-`validate / …` names from the manual release workflow. Avoid path filters on required
-checks. Add further checks only after their real runs are healthy.
+The first five job identifiers and Node matrix values are preserved. The ruleset uses
+the observed PR context names rather than nested `validate / …` names from the manual
+release workflow. It requires branches to be up to date and has no path filters.
 
 `protect-release-tags` (ID 22617499) is already Active for `v*.*.*`, blocking updates,
 deletion and non-fast-forward changes with no bypass actors. Preserve it and v0.9.0.
@@ -47,21 +46,17 @@ and analysis). Enable/check each independently:
 
 | Feature | Expected state / next action |
 | --- | --- |
-| Dependency graph | **Action required:** Dependency Review run 34342823536 failed: graph not enabled / review unsupported. Enable it and rerun the check. |
+| Dependency graph | Enabled with vulnerability alerts; Dependency Review run 34348461644 passed after enablement |
 | Dependabot alerts | Enabled; triage high/critical findings |
 | Dependabot security updates | Enabled; weekly version updates are configured in YAML |
 | Secret Protection → Secret scanning | Enabled |
 | Secret Protection → Push protection | Enabled |
-| Private vulnerability reporting | Enabled; confirm Security → Advisories → Report a vulnerability appears |
-| Code scanning → CodeQL | Use Advanced setup from this PR; disable conflicting Default setup if already enabled |
+| Private vulnerability reporting | Enabled; the repository API returned `enabled: true` |
+| Code scanning → CodeQL | Advanced workflow passed on PR #19; first main execution remains pending |
 
-Public-repository availability does not prove a feature is configured. The connector
-cannot read these sensitive endpoints, so verify in the UI and record the date.
-Dependency Review specifically returned: "Dependency review is not supported on this
-repository. Please ensure that Dependency graph is enabled". Direct settings path:
-https://github.com/cucuwang/geoptimize/settings/security_analysis. This check is
-intentionally left blocking until the setting is enabled; do not add continue-on-error.
-Do not create a PAT solely to make these checks pass.
+The initial Dependency Review failure reported that the dependency graph was disabled.
+After enablement, the same head passed without suppressing the check or adding a PAT.
+Recheck these settings through the API and UI after ownership or security-plan changes.
 
 ## Immutable releases (state not confirmed)
 

--- a/docs/maintainer-security-settings.md
+++ b/docs/maintainer-security-settings.md
@@ -1,0 +1,102 @@
+# Maintainer security settings
+
+Snapshot: 2026-09-09. Configuration files do not prove account settings are enabled.
+The connected API exposes ruleset reads, but no supported administration mutation.
+No account settings, credentials, production tags or releases were changed by this PR.
+
+## GitHub rulesets
+
+Settings → Rules → Rulesets → `protect-main` (ID 22617494) currently blocks deletion
+and force pushes only. It also targets two maintenance branches. Preserve that
+coverage; create a separate **main-required-checks** branch ruleset targeting `main`
+to avoid requiring new checks on historical maintenance branches.
+
+Set enforcement Active, no routine bypass actors, and enable:
+
+- Require a pull request before merging; required approvals **0** for the current
+  single maintainer. Leave required CODEOWNER review and last-push approval off.
+- Require conversation resolution before merging.
+- Require status checks to pass; require branches to be up to date before merging.
+- Block deletions and force pushes (already provided by protect-main).
+
+After the PR checks have run, choose these exact GitHub Actions contexts:
+
+| Required context | Source |
+| --- | --- |
+| `test-and-build (22)` | CI |
+| `test-and-build (24)` | CI |
+| `release-candidate-reproducibility` | CI |
+| `lint-readme-commands` | CI |
+| `action-contract` | CI |
+| `dependency-review` | Dependency Review |
+| `CodeQL (javascript-typescript)` | CodeQL |
+| `CodeQL (actions)` | CodeQL |
+
+The first five job identifiers and Node matrix values are preserved. Select the
+observed context names in Settings after successful runs; do not select the nested
+`validate / …` names from the manual release workflow. Avoid path filters on required
+checks. Add further checks only after their real runs are healthy.
+
+`protect-release-tags` (ID 22617499) is already Active for `v*.*.*`, blocking updates,
+deletion and non-fast-forward changes with no bypass actors. Preserve it and v0.9.0.
+
+## Security feature settings (state not confirmed)
+
+Open repository Settings → Security → **Advanced Security** (older UI: Code security
+and analysis). Enable/check each independently:
+
+| Feature | Expected state / next action |
+| --- | --- |
+| Dependency graph | Enabled; required by dependency review |
+| Dependabot alerts | Enabled; triage high/critical findings |
+| Dependabot security updates | Enabled; weekly version updates are configured in YAML |
+| Secret Protection → Secret scanning | Enabled |
+| Secret Protection → Push protection | Enabled |
+| Private vulnerability reporting | Enabled; confirm Security → Advisories → Report a vulnerability appears |
+| Code scanning → CodeQL | Use Advanced setup from this PR; disable conflicting Default setup if already enabled |
+
+Public-repository availability does not prove a feature is configured. The connector
+cannot read these sensitive endpoints, so verify in the UI and record the date.
+Do not create a PAT solely to make these checks pass.
+
+## Immutable releases (state not confirmed)
+
+Settings → General → Releases → **Enable release immutability**. This applies to
+future releases, not existing v0.9.0. Save before the next publication.
+The workflow creates a draft, uploads tarball/checksums/SBOM, publishes npm, then
+publishes the draft. A finalized immutable release cannot have assets replaced;
+recover by fixing forward. Review Marketplace metadata/terms before dispatch because
+finalization must happen only after all desired assets and metadata are in place.
+
+## npm Trusted Publisher and release gate
+
+1. npmjs.com → package **geoptimize** → Settings → Trusted Publisher → GitHub Actions.
+2. Organization/user: `cucuwang`; repository: `geoptimize`; workflow filename:
+   `release.yml`; environment: `npm-release` (exact spelling; no directory prefix).
+3. GitHub Settings → Environments → New environment `npm-release`. Restrict deployment
+   branches to `main`. Configure cucuwang as reviewer if available; allow self-review
+   for a single maintainer, otherwise the workflow cannot be approved.
+4. After all checklist items and a successful dry run, Settings → Secrets and
+   variables → Actions → Variables: set `RELEASE_ENABLED` to `true`.
+5. Do not add an npm token. The publication job uses GitHub-hosted Node 24 and checks
+   npm >=11.5.1; npm OIDC supplies short-lived authorization.
+6. Actual publication requires a separate authorization and manual dispatch with
+   `publish=true`; the default remains false. No tag-push auto-publication exists.
+
+## Signing identity and OpenSSF
+
+GitHub account Settings → SSH and GPG keys: register an existing approved public
+signing key (SSH key type: Signing key, or GPG public key). Configure signing locally
+following GitHub's signing guide. This PR does not create or manage keys. Verify a
+new annotated signed tag with `git tag -v` and GitHub's Verified indicator; a verified
+commit with an unsigned/lightweight tag is insufficient.
+
+At https://www.bestpractices.dev/ sign in and register
+`https://github.com/cucuwang/geoptimize`. Complete the Passing questionnaire using
+[the gap analysis](openssf-best-practices.md). Only add its badge after the service
+actually awards Passing. Scorecard's result badge is likewise deferred until a
+successful main-branch upload is visible at scorecard.dev.
+
+References: [npm OIDC](https://docs.npmjs.com/trusted-publishers/),
+[immutable releases](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes),
+[signing tags](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags).

--- a/docs/maintainer-security-settings.md
+++ b/docs/maintainer-security-settings.md
@@ -40,14 +40,14 @@ checks. Add further checks only after their real runs are healthy.
 `protect-release-tags` (ID 22617499) is already Active for `v*.*.*`, blocking updates,
 deletion and non-fast-forward changes with no bypass actors. Preserve it and v0.9.0.
 
-## Security feature settings (state not confirmed)
+## Security feature settings
 
 Open repository Settings → Security → **Advanced Security** (older UI: Code security
 and analysis). Enable/check each independently:
 
 | Feature | Expected state / next action |
 | --- | --- |
-| Dependency graph | Enabled; required by dependency review |
+| Dependency graph | **Action required:** Dependency Review run 34342823536 failed: graph not enabled / review unsupported. Enable it and rerun the check. |
 | Dependabot alerts | Enabled; triage high/critical findings |
 | Dependabot security updates | Enabled; weekly version updates are configured in YAML |
 | Secret Protection → Secret scanning | Enabled |
@@ -57,6 +57,10 @@ and analysis). Enable/check each independently:
 
 Public-repository availability does not prove a feature is configured. The connector
 cannot read these sensitive endpoints, so verify in the UI and record the date.
+Dependency Review specifically returned: "Dependency review is not supported on this
+repository. Please ensure that Dependency graph is enabled". Direct settings path:
+https://github.com/cucuwang/geoptimize/settings/security_analysis. This check is
+intentionally left blocking until the setting is enabled; do not add continue-on-error.
 Do not create a PAT solely to make these checks pass.
 
 ## Immutable releases (state not confirmed)

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -25,8 +25,8 @@ transitive dependency or the maintainer's historical response performance.
 
 | Work | Status / evidence needed |
 | --- | --- |
-| Static analysis for application and workflow sources | CodeQL added; first successful runs and finding triage required |
-| Automated dependency review and updates | Dependency Review, Dependabot added; resolve actionable results |
+| Static analysis for application and workflow sources | CodeQL passed on PR #19; first main run and ongoing finding triage remain |
+| Automated dependency review and updates | Dependency Review passed; Dependabot alerts, security updates and weekly version updates are enabled |
 | Verifiable release integrity | OIDC workflow, SBOM, checksums and attestation prepared; next authorized release supplies public evidence |
 | Document operational trust boundaries | Release/settings/Action decision documents added |
 | Release notes for security fixes | Changelog process exists; describe actual fixes and identifiers when applicable |
@@ -36,8 +36,8 @@ transitive dependency or the maintainer's historical response performance.
 - Register the project and answer all Passing criteria with public evidence links.
 - `know_secure_design` / `know_common_errors`: identify a primary developer who can
   substantiate secure-design and common-error knowledge. A workflow cannot prove this.
-- Confirm actual private reporting availability and monitor acknowledgement/remediation
-  performance; do not infer historical responsiveness from a written target.
+- Private reporting is enabled; monitor acknowledgement/remediation performance rather
+  than inferring historical responsiveness from a written target.
 - Review outstanding static-analysis, dependency and reported vulnerability findings;
   document severity, disposition and timely fixes. Audit success is time-bound.
 - Confirm test-policy enforcement for new functionality and fixes, and that important

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -1,0 +1,61 @@
+# OpenSSF Best Practices: Passing gap analysis
+
+Assessment date: 2026-09-09. This is evidence preparation, not a certification or
+completed questionnaire. [Official Passing criteria](https://www.bestpractices.dev/en/criteria/0?details=true&rationale=true)
+remain authoritative; review every applicable MUST/MUST NOT and justify SHOULD items
+when registering. Silver and Gold are outside scope.
+
+## Already satisfied (repository evidence)
+
+| Criterion area | Evidence |
+| --- | --- |
+| Purpose, basic usage, supported environment | README quick start; package.json engines |
+| Free/open-source license and source availability | Public Git repository, MIT LICENSE, npm repository metadata |
+| Version control and uniquely identified releases | Git history; historical version tags; CHANGELOG and release runbooks |
+| Contribution process and public issue reporting | CONTRIBUTING.md, GitHub issues, focused issue/PR templates |
+| Reproducible build instructions and automated test entry point | npm ci, npm run check, lockfile, test sources and public fixtures |
+| Interface and limitations documentation | README, methodology, versioned JSON contracts and tests |
+| Vulnerability reporting process | SECURITY.md safe-reporting guidance and seven-day acknowledgement target |
+
+These are observable artifacts, not a declaration that every criterion in an area
+is met. Public source availability does not establish license compatibility of every
+transitive dependency or the maintainer's historical response performance.
+
+## Repository changes required
+
+| Work | Status / evidence needed |
+| --- | --- |
+| Static analysis for application and workflow sources | CodeQL added; first successful runs and finding triage required |
+| Automated dependency review and updates | Dependency Review, Dependabot added; resolve actionable results |
+| Verifiable release integrity | OIDC workflow, SBOM, checksums and attestation prepared; next authorized release supplies public evidence |
+| Document operational trust boundaries | Release/settings/Action decision documents added |
+| Release notes for security fixes | Changelog process exists; describe actual fixes and identifiers when applicable |
+
+## Maintainer/manual verification required
+
+- Register the project and answer all Passing criteria with public evidence links.
+- `know_secure_design` / `know_common_errors`: identify a primary developer who can
+  substantiate secure-design and common-error knowledge. A workflow cannot prove this.
+- Confirm actual private reporting availability and monitor acknowledgement/remediation
+  performance; do not infer historical responsiveness from a written target.
+- Review outstanding static-analysis, dependency and reported vulnerability findings;
+  document severity, disposition and timely fixes. Audit success is time-bound.
+- Confirm test-policy enforcement for new functionality and fixes, and that important
+  functionality is exercised. Test count alone cannot establish adequacy.
+- Review distributed dependencies' license obligations and maintain appropriate notices.
+- Verify secure transport for distribution, current cryptographic library use, entropy
+  requirements where relevant, and absence of known unpatched exploitable vulnerabilities.
+- Confirm English/public documentation and issue/release accessibility, user support
+  expectations, and release-note practice against the complete live questionnaire.
+- Only insert the Best Practices badge after the service awards Passing. Scorecard is
+  a separate automated assessment and does not award this badge.
+
+## Not applicable (bounded, requires maintainer confirmation)
+
+- Project-owned encryption/signature algorithms or custom password storage: none are
+  introduced here. HTTPS/TLS is delegated to runtime/platform implementations; assess
+  applicable cryptographic-use criteria separately rather than marking all crypto N/A.
+- Memory-unsafe implementation analysis: first-party code is TypeScript/JavaScript;
+  this does not exempt dependencies, browser interaction or input validation.
+- No specific N/A questionnaire answer is preselected. Use N/A only where the actual
+  criterion allows it and the current code review supports the explanation.

--- a/docs/release-notes-v0.10.md
+++ b/docs/release-notes-v0.10.md
@@ -1,0 +1,22 @@
+# geoptimize 0.10.0
+
+## Release integrity
+
+- Publishes the exact tarball validated by CI on Node.js 22 and 24.
+- Adds npm provenance and GitHub artifact attestation for the release tarball.
+- Includes SHA-256 checksums and an SPDX 2.3 production-dependency SBOM.
+- Pins GitHub Actions to reviewed upstream commits and applies least-privilege workflow permissions.
+
+## Compatibility
+
+Scoring, CLI, API, JSON output and composite Action contracts remain unchanged.
+
+## Install
+
+```bash
+npm install --save-dev geoptimize@0.10.0
+```
+
+```bash
+npx geoptimize scan ./dist --dir
+```

--- a/docs/release-v0.10.md
+++ b/docs/release-v0.10.md
@@ -1,0 +1,92 @@
+# v0.10 trust-hardening release runbook
+
+Status: repository preparation; package version remains 0.9.0 until an approved
+version-bump PR. Nothing in this document asserts that 0.10.0 has been published.
+Scoring, CLI/API/JSON and composite Action contracts remain unchanged.
+
+## Candidate and dry run
+
+The reusable CI workflow remains the single acceptance pipeline. On both Node 22
+and 24 it runs `npm ci` and `npm run release:check`: clean worktree, tests, TypeScript,
+Action shell contract, high/critical npm audit gate, package contents, clean consumer
+installation, all three aliases and report contracts. Separate jobs exercise the
+actual composite Action, README commands and byte-identical Node candidate manifests.
+
+The verifier can export its already-tested tarball via `RELEASE_TARBALL_OUT`; it never
+re-packs for publication. Node 24 prepares a production SPDX 2.3 SBOM, SHA256SUMS and
+runs `npm publish <tarball> --dry-run --ignore-scripts`. PR CI exercises this path.
+`--ignore-scripts` applies to publishing the existing tarball only; all acceptance
+checks have already executed explicitly. Existing prepublishOnly remains intact.
+
+Local reproduction from a committed, clean checkout:
+
+```bash
+npm ci
+npm test
+npm run build
+release_dir=$(mktemp -d)
+version=$(node -p "JSON.parse(require('fs').readFileSync('package.json')).version")
+RELEASE_MANIFEST_OUT="$release_dir/candidate.json" RELEASE_TARBALL_OUT="$release_dir/geoptimize-$version.tgz" npm run release:check
+node scripts/prepare-release-artifacts.mjs "$release_dir"
+(cd "$release_dir" && sha256sum --check SHA256SUMS)
+npm publish "$release_dir/geoptimize-$version.tgz" --dry-run --ignore-scripts --access public
+```
+
+On GitHub, Actions → Release → Run workflow → branch main → leave publish false.
+All CI gates run and release-assets is retained; no signing, OIDC publication,
+attestation or GitHub Release writes occur. A successful dry run proves packaging,
+not external npm authorization or immutable-release settings.
+
+## Authorized next release
+
+1. Complete [maintainer settings](maintainer-security-settings.md), including npm
+   environment binding, main required checks, immutable releases and signing identity.
+2. Prepare a separate version-bump PR updating package/lock, CLI and plugin metadata,
+   both Action defaults, sample pins, hard-coded CI tarball fixtures, changelog and
+   release-contract expectations. Run all gates. Do not rewrite v0.9.0.
+3. Merge the approved release commit, fetch origin/main, and ensure it is still main's
+   exact HEAD. With explicit release authorization, create an annotated signed tag
+   (`git tag -s v0.10.0 <commit> -m 'geoptimize 0.10.0'`) and push only that tag.
+   Verify it locally and on GitHub. Do not create or move tags as part of hardening.
+4. Dispatch Release on main with tag `v0.10.0`, publish true. Confirm the run commit
+   matches the tag. Approve npm-release after reviewing the CI results and artifacts.
+5. Preflight rejects unsigned/lightweight tags, wrong SHA/version/repository, dirty
+   source, changed main HEAD, corrupted artifacts and already-published npm versions.
+6. Attest the tarball; create a draft with all assets; publish that exact tarball with
+   npm OIDC/provenance; finalize the draft; run the existing public readback verifier.
+
+Expected assets: `geoptimize-0.10.0.tgz`, `geoptimize-0.10.0.spdx.json`, `SHA256SUMS`.
+The Actions artifact also retains candidate.json. Filenames are version-derived.
+Checksums are calculated from actual artifact bytes, including the SBOM.
+
+## What the evidence establishes
+
+- npm provenance links the registry package to its GitHub build/publish workflow and
+  source identity. Inspect npm's provenance UI or `npm audit signatures` in a clean
+  consumer installation.
+- GitHub Artifact Attestation lets a downloader verify the release tarball directly:
+  `gh attestation verify geoptimize-0.10.0.tgz --repo cucuwang/geoptimize`.
+- SHA256SUMS detects byte changes; trust it through the attested tarball and the
+  immutable release. Hashes alone do not authenticate an author.
+- SPDX describes the release commit's locked production dependency resolution and
+  binds its root package to the exact tarball hash. Dev tools are omitted. Dependencies
+  are not bundled: downstream npm installs can resolve different compatible versions.
+  It is not a promise of byte-identical consumer dependency trees. SBOM metadata may
+  contain generation timestamps; tarball reproducibility is the enforced invariant.
+
+References: [npm SBOM](https://docs.npmjs.com/cli/v11/commands/npm-sbom/),
+[npm trusted publishing](https://docs.npmjs.com/trusted-publishers/),
+[GitHub attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations),
+[immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
+
+## Recovery
+
+Publication crosses two services and cannot be atomic. If draft staging succeeds but
+npm fails, leave the draft and inspect logs; do not finalize it. If npm succeeds and
+GitHub finalization/readback fails, do not rerun npm publication: verify npm tarball
+hash/provenance, uploaded assets and signed tag, then finalize the existing draft with
+explicit authorization. A normal rerun fails closed on an existing version or draft.
+Never overwrite assets on a finalized release or retag an existing version. Deprecate
+or adjust dist-tags only with authorization, preserving audit evidence and fixing
+forward. An advanced main branch requires a new release decision, not bypassing the
+exact-main source gate.

--- a/docs/release-v0.10.md
+++ b/docs/release-v0.10.md
@@ -34,6 +34,11 @@ node scripts/prepare-release-artifacts.mjs "$release_dir"
 npm pack "$release_dir/geoptimize-$version.tgz" --dry-run --ignore-scripts --json
 ```
 
+The candidate gate extracts `package/README.md` from the verified tarball and requires
+it to be non-empty. After publication, open the npm package page and confirm that the
+README renders. The registry metadata `readme` field can be empty while npm still
+renders the packaged README, so that field alone is not a publication failure.
+
 On GitHub, Actions → Release → Run workflow → branch main → leave publish false.
 All CI gates run and release-assets is retained; no signing, OIDC publication,
 attestation or GitHub Release writes occur. A successful dry run proves packaging,
@@ -56,6 +61,10 @@ not external npm authorization or immutable-release settings.
    source, changed main HEAD, corrupted artifacts and already-published npm versions.
 6. Attest the tarball; create a draft with all assets; publish that exact tarball with
    npm OIDC/provenance; finalize the draft; run the existing public readback verifier.
+
+The GitHub Release uses [public release notes](release-notes-v0.10.md). Keep setup,
+approval and recovery instructions in this runbook rather than publishing them as the
+release description.
 
 Expected assets: `geoptimize-0.10.0.tgz`, `geoptimize-0.10.0.spdx.json`, `SHA256SUMS`.
 The Actions artifact also retains candidate.json. Filenames are version-derived.

--- a/docs/release-v0.10.md
+++ b/docs/release-v0.10.md
@@ -14,7 +14,9 @@ actual composite Action, README commands and byte-identical Node candidate manif
 
 The verifier can export its already-tested tarball via `RELEASE_TARBALL_OUT`; it never
 re-packs for publication. Node 24 prepares a production SPDX 2.3 SBOM, SHA256SUMS and
-runs `npm publish <tarball> --dry-run --ignore-scripts`. PR CI exercises this path.
+previews the exact tarball with `npm pack <tarball> --dry-run --ignore-scripts`.
+PR CI exercises this non-publishing path. npm publish --dry-run rejects an already
+published version, so ordinary PRs use pack preview without bypassing that safeguard.
 `--ignore-scripts` applies to publishing the existing tarball only; all acceptance
 checks have already executed explicitly. Existing prepublishOnly remains intact.
 
@@ -29,7 +31,7 @@ version=$(node -p "JSON.parse(require('fs').readFileSync('package.json')).versio
 RELEASE_MANIFEST_OUT="$release_dir/candidate.json" RELEASE_TARBALL_OUT="$release_dir/geoptimize-$version.tgz" npm run release:check
 node scripts/prepare-release-artifacts.mjs "$release_dir"
 (cd "$release_dir" && sha256sum --check SHA256SUMS)
-npm publish "$release_dir/geoptimize-$version.tgz" --dry-run --ignore-scripts --access public
+npm pack "$release_dir/geoptimize-$version.tgz" --dry-run --ignore-scripts --json
 ```
 
 On GitHub, Actions → Release → Run workflow → branch main → leave publish false.

--- a/docs/trust-hardening-validation.md
+++ b/docs/trust-hardening-validation.md
@@ -30,19 +30,24 @@ The initial npm publish --dry-run correctly rejected already-published 0.9.0.
 PR preview now uses npm pack --dry-run against the verified tarball, with no force
 flag or weakened version/security gate. No package was published.
 
-## GitHub evidence before the final documentation update
+## GitHub evidence on the current PR head
 
-Commit `1f6d7de6b1a7c5164f12a445813c1f4224aab6e4`:
+Commit `17986f9258d38028e06e47265ffc36c0878e361d`:
 
-- [CI run 34342957970](https://github.com/cucuwang/geoptimize/actions/runs/34342957970):
+- [CI run 34348461590](https://github.com/cucuwang/geoptimize/actions/runs/34348461590):
   test-and-build (22), test-and-build (24), release-candidate-reproducibility,
   lint-readme-commands and action-contract all passed. Node 24 also generated release
   assets/SBOM/checksums and exercised the non-publishing tarball preview.
-- [CodeQL run 34342957988](https://github.com/cucuwang/geoptimize/actions/runs/34342957988):
+- [CodeQL run 34348461591](https://github.com/cucuwang/geoptimize/actions/runs/34348461591):
   JavaScript/TypeScript and GitHub Actions analyses both passed.
-- [Dependency Review run 34342957977](https://github.com/cucuwang/geoptimize/actions/runs/34342957977):
-  blocked because Dependency graph is not enabled/review is unsupported. Maintainer
-  must enable the graph, then rerun; this failure has not been suppressed.
+- [Dependency Review run 34348461644](https://github.com/cucuwang/geoptimize/actions/runs/34348461644):
+  passed after the dependency graph and vulnerability alerts were enabled. The failure
+  was rerun without weakening its severity gate.
+- `main-required-checks` ruleset 22637595 is Active with no bypass actors. It requires
+  a pull request, resolved conversations, an up-to-date branch and all eight documented
+  CI, Dependency Review and CodeQL contexts.
+- Dependabot security updates and private vulnerability reporting were enabled and
+  returned `enabled: true`. Secret scanning and push protection remain enabled.
 
 The PR checks panel is authoritative for the latest commit. Documentation changes
 also affect the npm tarball, so require a fresh successful reproducibility run before
@@ -58,12 +63,12 @@ existing scoring contract tests pass. The only new src file is a preflight test.
   only static/preflight validation.
 - Scorecard is configured for main pushes/schedule and awaits its first main run.
   Syntax and upstream pin were verified; no successful score or badge is asserted.
-- Private reporting, secret scanning/push protection, immutable-release setting,
-  OpenSSF registration and signing identity remain maintainer UI gates.
+- Immutable-release setting, npm Trusted Publisher/environment, OpenSSF registration
+  and signing identity remain maintainer gates.
 
 ## Public issue reconciliation
 
-#11 retains Marketplace live-listing verification. #16 replaces the stale npm 404
-with verified 0.9.0 metadata and retains Mac/readback follow-ups. #9/#10 examples use
-the current name/version; their feature/test scope stays open. Historical dogfood
-reports were preserved. Bundling is tracked in [#20](https://github.com/cucuwang/geoptimize/issues/20).
+#11's Marketplace listing was verified for owner cucuwang and version 0.9.0. #16's
+Mac checkout now uses the geoptimize origin, and the original 0.9.0 candidate hash,
+public tarball, three aliases, tag and Release were read back successfully. #9/#10
+retain their feature scope. Bundling remains tracked in [#20](https://github.com/cucuwang/geoptimize/issues/20).

--- a/docs/trust-hardening-validation.md
+++ b/docs/trust-hardening-validation.md
@@ -30,7 +30,7 @@ The initial npm publish --dry-run correctly rejected already-published 0.9.0.
 PR preview now uses npm pack --dry-run against the verified tarball, with no force
 flag or weakened version/security gate. No package was published.
 
-## GitHub evidence on the current PR head
+## GitHub evidence before the applied-settings documentation update
 
 Commit `17986f9258d38028e06e47265ffc36c0878e361d`:
 

--- a/docs/trust-hardening-validation.md
+++ b/docs/trust-hardening-validation.md
@@ -1,0 +1,66 @@
+# Trust-hardening validation record
+
+2026-09-09, PR [#19](https://github.com/cucuwang/geoptimize/pull/19).
+
+## Executed locally
+
+| Command / check | Result |
+| --- | --- |
+| npm ci | Passed on Node 24.19.0 / npm 11.9.0 |
+| npm test | Original 231 tests passed |
+| npm test -- --run src/core/__tests__/release-publication.test.ts | 10 additional preflight tests passed |
+| npm run build | Passed |
+| npm run release:check | Passed with all 241 tests, Action contract, audit, package contents, clean consumer, aliases and report checks |
+| npm audit --audit-level=high (inside release:check) | 0 vulnerabilities at test time |
+| node scripts/prepare-release-artifacts.mjs /tmp/geoptimize-trust-artifacts | SPDX generated and root identity/hash validated |
+| sha256sum --check SHA256SUMS | Tarball and SPDX both passed |
+| npm pack <verified-tarball> --dry-run --ignore-scripts --json | Passed; geoptimize 0.9.0, 90 package files |
+| actionlint 1.7.12 -shellcheck='' | All workflow syntax/expressions passed; ShellCheck was unavailable and was not claimed |
+| Python yaml.safe_load on workflows, Dependabot and issue config | Passed; all external uses references are 40-character SHAs |
+| node --check scripts/prepare-release-artifacts.mjs; bash -n scripts/verify-release-publication.sh | Passed |
+| git diff --check | Passed |
+
+Actionlint download SHA-256 was checked against the official GitHub release asset:
+`8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`.
+
+The initial npm publish --dry-run correctly rejected already-published 0.9.0.
+PR preview now uses npm pack --dry-run against the verified tarball, with no force
+flag or weakened version/security gate. No package was published.
+
+## GitHub evidence before the final documentation update
+
+Commit `1f6d7de6b1a7c5164f12a445813c1f4224aab6e4`:
+
+- [CI run 34342957970](https://github.com/cucuwang/geoptimize/actions/runs/34342957970):
+  test-and-build (22), test-and-build (24), release-candidate-reproducibility,
+  lint-readme-commands and action-contract all passed. Node 24 also generated release
+  assets/SBOM/checksums and exercised the non-publishing tarball preview.
+- [CodeQL run 34342957988](https://github.com/cucuwang/geoptimize/actions/runs/34342957988):
+  JavaScript/TypeScript and GitHub Actions analyses both passed.
+- [Dependency Review run 34342957977](https://github.com/cucuwang/geoptimize/actions/runs/34342957977):
+  blocked because Dependency graph is not enabled/review is unsupported. Maintainer
+  must enable the graph, then rerun; this failure has not been suppressed.
+
+The PR checks panel is authoritative for the latest commit. Documentation changes
+also affect the npm tarball, so require a fresh successful reproducibility run before
+merging. Production source/scoring code and existing fixtures were not modified;
+existing scoring contract tests pass. The only new src file is a preflight test.
+
+## Not executed / not established
+
+- Actual npm OIDC authentication, provenance and GitHub attestation issuance require
+  the authorized release path and account setup; dry-run cannot prove these.
+- The manual release dispatcher is available after merge to main. Its full reusable
+  CI/non-publishing pipeline has been exercised by PR CI; publication steps have
+  only static/preflight validation.
+- Scorecard is configured for main pushes/schedule and awaits its first main run.
+  Syntax and upstream pin were verified; no successful score or badge is asserted.
+- Private reporting, secret scanning/push protection, immutable-release setting,
+  OpenSSF registration and signing identity remain maintainer UI gates.
+
+## Public issue reconciliation
+
+#11 retains Marketplace live-listing verification. #16 replaces the stale npm 404
+with verified 0.9.0 metadata and retains Mac/readback follow-ups. #9/#10 examples use
+the current name/version; their feature/test scope stays open. Historical dogfood
+reports were preserved. Bundling is tracked in [#20](https://github.com/cucuwang/geoptimize/issues/20).

--- a/docs/trust-hardening-validation.md
+++ b/docs/trust-hardening-validation.md
@@ -7,10 +7,10 @@
 | Command / check | Result |
 | --- | --- |
 | npm ci | Passed on Node 24.19.0 / npm 11.9.0 |
-| npm test | Original 231 tests passed |
+| npm test | Original 231 tests plus 11 release-hardening tests passed; 242 total |
 | npm test -- --run src/core/__tests__/release-publication.test.ts | 10 additional preflight tests passed |
 | npm run build | Passed |
-| npm run release:check | Passed with all 241 tests, Action contract, audit, package contents, clean consumer, aliases and report checks |
+| npm run release:check | Passed with all 242 tests, Action contract, audit, package contents, non-empty packaged README, clean consumer, aliases and report checks |
 | npm audit --audit-level=high (inside release:check) | 0 vulnerabilities at test time |
 | node scripts/prepare-release-artifacts.mjs /tmp/geoptimize-trust-artifacts | SPDX generated and root identity/hash validated |
 | sha256sum --check SHA256SUMS | Tarball and SPDX both passed |
@@ -19,6 +19,9 @@
 | Python yaml.safe_load on workflows, Dependabot and issue config | Passed; all external uses references are 40-character SHAs |
 | node --check scripts/prepare-release-artifacts.mjs; bash -n scripts/verify-release-publication.sh | Passed |
 | git diff --check | Passed |
+
+The release workflow uses a public release-notes file rather than publishing this
+maintainer runbook. A contract test keeps the two paths separate.
 
 Actionlint download SHA-256 was checked against the official GitHub release asset:
 `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "scripts/verify-release-v0.8.sh",
     "docs/release-v0.9.md",
     "docs/visual-report.md",
-    "docs/assets/"
+    "docs/assets/",
+    "docs/release-v0.10.md",
+    "docs/maintainer-security-settings.md",
+    "docs/openssf-best-practices.md",
+    "docs/action-reproducibility.md"
   ],
   "scripts": {
     "build": "tsc",

--- a/scripts/prepare-release-artifacts.mjs
+++ b/scripts/prepare-release-artifacts.mjs
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync, realpathSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+
+// No build or pack here: export the exact tarball that passed release:check.
+const out = realpathSync(process.argv[2]);
+const root = resolve(import.meta.dirname, '..');
+if (out === root || out.startsWith(root + '/')) throw new Error('Use an artifact directory outside the checkout');
+const pkg = JSON.parse(readFileSync(join(root, 'package.json')));
+const manifest = JSON.parse(readFileSync(join(out, 'candidate.json')));
+if (pkg.name !== 'geoptimize' || !/^\d+\.\d+\.\d+$/.test(pkg.version)) throw new Error('Unexpected package identity');
+if (manifest.version !== pkg.version || manifest.filename !== `geoptimize-${pkg.version}.tgz`) throw new Error('Candidate identity mismatch');
+const hash = data => createHash('sha256').update(data).digest('hex');
+const tgz = join(out, manifest.filename);
+if (hash(readFileSync(tgz)) !== manifest.sha256) throw new Error('Candidate hash mismatch');
+const packed = JSON.parse(execFileSync('tar', ['-xOf', tgz, 'package/package.json'], {encoding: 'utf8'}));
+for (const field of ['name', 'version', 'repository', 'dependencies', 'bin']) {
+  if (JSON.stringify(packed[field]) !== JSON.stringify(pkg[field])) throw new Error(`Packed ${field} mismatch`);
+}
+const sbom = JSON.parse(execFileSync('npm', ['sbom', '--sbom-format=spdx', '--package-lock-only', '--omit=dev'], {cwd: root, encoding:'utf8'}));
+if (sbom.spdxVersion !== 'SPDX-2.3') throw new Error('Unexpected SPDX format');
+const subject = sbom.packages.find(p => p.name === pkg.name && p.versionInfo === pkg.version);
+if (!subject || !sbom.documentDescribes.includes(subject.SPDXID)) throw new Error('SBOM root mismatch');
+subject.packageFileName = manifest.filename;
+subject.checksums = [{algorithm: 'SHA256', checksumValue: manifest.sha256}];
+subject.sourceInfo = 'Production dependency resolution from the release commit package-lock.json; npm consumers may resolve different versions within declared ranges.';
+const name = `geoptimize-${pkg.version}.spdx.json`;
+const data = JSON.stringify(sbom, null, 2) + '\n';
+writeFileSync(join(out, name), data);
+writeFileSync(join(out, 'SHA256SUMS'), `${manifest.sha256}  ${manifest.filename}\n${hash(data)}  ${name}\n`);
+console.log(`Prepared ${manifest.filename}, ${name}, SHA256SUMS`);

--- a/scripts/verify-release-candidate.sh
+++ b/scripts/verify-release-candidate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
 
-for command_name in git jq mktemp node npm; do
+for command_name in git jq mktemp node npm tar; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
     echo "missing required command: $command_name" >&2
     exit 2
@@ -55,6 +55,7 @@ PACKAGE_TARBALL="$PACK_ROOT/$PACKAGE_FILENAME"
 PACKAGE_SHA256=$(node -e "const crypto=require('node:crypto');const fs=require('node:fs');console.log(crypto.createHash('sha256').update(fs.readFileSync(process.argv[1])).digest('hex'))" "$PACKAGE_TARBALL")
 
 jq -e '
+  (.[0].files | map(.path) | index("README.md")) != null and
   (.[0].files | map(.path) | index("dist/cli/index.js")) != null and
   (.[0].files | map(.path) | index("dist/core/audit.js")) != null and
   (.[0].files | map(.path) | index("dist/core/static-audit.js")) != null and
@@ -71,6 +72,12 @@ jq -e '
   (.[0].files | map(.path) | index("scripts/verify-release-candidate.sh")) != null and
   (.[0].files | map(.path) | index("scripts/verify-release-v0.8.sh")) != null
 ' "$PACK_JSON" >/dev/null
+
+if ! tar -xOf "$PACKAGE_TARBALL" package/README.md > "$VERIFY_ROOT/README.md" || \
+   [ ! -s "$VERIFY_ROOT/README.md" ]; then
+  echo "package README.md is missing or empty" >&2
+  exit 1
+fi
 
 npm_config_dry_run=false npm --cache "$VERIFY_ROOT/npm-cache" install \
   --ignore-scripts --no-audit --no-fund \

--- a/scripts/verify-release-candidate.sh
+++ b/scripts/verify-release-candidate.sh
@@ -122,5 +122,9 @@ if [ -n "${RELEASE_MANIFEST_OUT:-}" ]; then
   printf '%s\n' "$MANIFEST" > "$RELEASE_MANIFEST_OUT"
 fi
 
+if [ -n "${RELEASE_TARBALL_OUT:-}" ]; then
+  cp "$PACKAGE_TARBALL" "$RELEASE_TARBALL_OUT"
+fi
+
 printf '%s\n' "$MANIFEST"
 echo "Release candidate checks passed."

--- a/scripts/verify-release-publication.sh
+++ b/scripts/verify-release-publication.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+assets=${1:?artifact directory required}
+: "${RELEASE_TAG:?existing signed tag required}"
+: "${GITHUB_SHA:?workflow commit required}"
+: "${GITHUB_REPOSITORY:?repository required}"
+test "$GITHUB_REPOSITORY" = cucuwang/geoptimize
+test -z "$(git status --porcelain)"
+bash scripts/verify-publish-source.sh
+test "$(gh api repos/cucuwang/geoptimize/git/ref/heads/main --jq .object.sha)" = "$GITHUB_SHA"
+version=$(node -p "JSON.parse(require('fs').readFileSync('package.json')).version")
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+test "$RELEASE_TAG" = "v$version"
+# A lightweight tag or a signed commit alone does not satisfy the signed-tag policy.
+ref=$(gh api "repos/cucuwang/geoptimize/git/ref/tags/$RELEASE_TAG")
+test "$(jq -r .object.type <<< "$ref")" = tag
+tag=$(gh api "repos/cucuwang/geoptimize/git/tags/$(jq -r .object.sha <<< "$ref")")
+jq -e --arg sha "$GITHUB_SHA" '.verification.verified == true and .object.type == "commit" and .object.sha == $sha' <<< "$tag" >/dev/null
+node - "$(npm --version)" <<'NODE'
+const [major, minor, patch] = process.argv[2].split('.').map(Number);
+if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) throw new Error('npm >=11.5.1 required for OIDC');
+NODE
+(cd "$assets" && sha256sum --check SHA256SUMS)
+jq -e --arg version "$version" '.version == $version and .filename == ("geoptimize-" + $version + ".tgz")' "$assets/candidate.json" >/dev/null
+test "$(sha256sum "$assets/geoptimize-$version.tgz" | cut -d ' ' -f1)" = "$(jq -r .sha256 "$assets/candidate.json")"
+# Fail closed on registry errors other than an explicit version-not-found result.
+lookup=$(mktemp)
+trap 'rm -f "$lookup"' EXIT
+if npm view "geoptimize@$version" version --json > "$lookup"; then
+  echo 'Version already exists: stop and inspect; never overwrite a release.' >&2
+  exit 1
+fi
+jq -e '.error.code == "E404"' "$lookup" >/dev/null
+# Existing drafts require deliberate recovery; create cannot silently overwrite one.
+echo "Publication preflight passed for $RELEASE_TAG at $GITHUB_SHA"

--- a/src/core/__tests__/release-contract.test.ts
+++ b/src/core/__tests__/release-contract.test.ts
@@ -179,6 +179,7 @@ describe('v0.6 JSON automation contract', () => {
   it('ships release and rollback instructions with the package', async () => {
     const packageJson = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8'));
     const releaseGuide = await readFile(join(repositoryRoot, 'docs/release-v0.9.md'), 'utf8');
+    const candidateVerifier = await readFile(join(repositoryRoot, 'scripts/verify-release-candidate.sh'), 'utf8');
     const publicVerifier = await readFile(join(repositoryRoot, 'scripts/verify-release-v0.8.sh'), 'utf8');
 
     expect(packageJson.files).toContain('docs/release-v0.9.md');
@@ -196,9 +197,24 @@ describe('v0.6 JSON automation contract', () => {
     expect(releaseGuide).toContain('## Rollback');
     expect(releaseGuide).toContain('npm dist-tag add geoptimize@0.8.0 latest');
     expect(releaseGuide).toContain('<verified-package-sha256>');
+    expect(candidateVerifier).toContain('index("README.md")');
+    expect(candidateVerifier).toContain('tar -xOf "$PACKAGE_TARBALL" package/README.md');
+    expect(candidateVerifier).toContain('[ ! -s "$VERIFY_ROOT/README.md" ]');
     expect(publicVerifier).toContain('.gitHead');
     expect(publicVerifier).toContain('EXPECTED_REPOSITORY_URL');
     expect(publicVerifier).toContain('.dist.tarball');
     expect(publicVerifier).toContain('EXPECTED_PACKAGE_SHA256');
+  });
+
+  it('keeps public release notes separate from the maintainer runbook', async () => {
+    const workflow = await readFile(join(repositoryRoot, '.github/workflows/release.yml'), 'utf8');
+    const releaseNotes = await readFile(join(repositoryRoot, 'docs/release-notes-v0.10.md'), 'utf8');
+    const runbook = await readFile(join(repositoryRoot, 'docs/release-v0.10.md'), 'utf8');
+
+    expect(workflow).toContain('--notes-file docs/release-notes-v0.10.md');
+    expect(workflow).not.toContain('--notes-file docs/release-v0.10.md');
+    expect(releaseNotes).toContain('# geoptimize 0.10.0');
+    expect(releaseNotes).not.toContain('repository preparation');
+    expect(runbook).toContain('Status: repository preparation');
   });
 });

--- a/src/core/__tests__/release-publication.test.ts
+++ b/src/core/__tests__/release-publication.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+const root = resolve(import.meta.dirname, '../../..');
+const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
+const sha = 'a'.repeat(40);
+function preflight(scenario: string) {
+  const temp = mkdtempSync(join(tmpdir(), 'geoptimize-preflight-'));
+  try {
+    const bin = join(temp, 'bin'); mkdirSync(bin);
+    const artifact = Buffer.from('verified-candidate-test-bytes');
+    const digest = createHash('sha256').update(artifact).digest('hex');
+    const filename = `geoptimize-${version}.tgz`;
+    writeFileSync(join(temp, filename), artifact);
+    writeFileSync(join(temp, 'candidate.json'), JSON.stringify({version, filename, sha256: digest}));
+    writeFileSync(join(temp, 'SHA256SUMS'), `${digest}  ${filename}\n`);
+    if (scenario === 'tampered') writeFileSync(join(temp, filename), 'changed');
+    const executable = (name: string, body: string) => writeFileSync(join(bin, name), '#!/usr/bin/env bash\n' + body, {mode: 0o755});
+    executable('git', `if [ "$1" = status ]; then
+      [ "$SCENARIO" != dirty ] || echo ' M package.json'
+      exit 0
+    fi
+    echo '${sha}'\n`);
+    executable('gh', `case "$2" in
+      */heads/main) if [ "$SCENARIO" = moved-main ]; then echo '${'b'.repeat(40)}'; else echo '${sha}'; fi ;;
+      */git/ref/tags/*) if [ "$SCENARIO" = lightweight ]; then echo '{"object":{"type":"commit","sha":"${sha}"}}'; else echo '{"object":{"type":"tag","sha":"${sha}"}}'; fi ;;
+      */git/tags/*) if [ "$SCENARIO" = unsigned ]; then verified=false; else verified=true; fi
+        if [ "$SCENARIO" = wrong-commit ]; then commit='${'b'.repeat(40)}'; else commit='${sha}'; fi
+        printf '{"verification":{"verified":%s},"object":{"type":"commit","sha":"%s"}}' "$verified" "$commit" ;;
+      *) exit 2 ;;
+    esac\n`);
+    executable('npm', `if [ "$1" = --version ]; then echo 11.9.0; exit 0; fi
+      if [ "$SCENARIO" = existing ]; then echo '"${version}"'; exit 0; fi
+      if [ "$SCENARIO" = registry-error ]; then echo '{"error":{"code":"E503"}}'; else echo '{"error":{"code":"E404"}}'; fi
+      exit 1\n`);
+    return spawnSync('bash', ['scripts/verify-release-publication.sh', temp], {
+      cwd: root, encoding:'utf8', env: {...process.env, PATH: `${bin}:${process.env.PATH}`, SCENARIO: scenario,
+        GITHUB_REPOSITORY:'cucuwang/geoptimize', GITHUB_SHA:sha, RELEASE_TAG:scenario === 'wrong-version' ? 'v999.0.0' : `v${version}`},
+    });
+  } finally { rmSync(temp, {recursive:true, force:true}); }
+}
+describe('publication preflight', () => {
+  it('accepts verified source/tag/hash and explicit registry E404', () => {
+    const result = preflight('valid');
+    expect(result.status, result.stderr).toBe(0);
+  });
+  for (const scenario of ['dirty','moved-main','lightweight','unsigned','wrong-commit','wrong-version','tampered','existing','registry-error']) {
+    it(`fails closed on ${scenario}`, () => expect(preflight(scenario).status).not.toBe(0));
+  }
+});


### PR DESCRIPTION
## Summary

Hardens CI, repository checks and the next-release path without changing scoring, CLI, API, JSON or composite Action behavior. Version remains 0.9.0; publication and merge remain separate maintainer decisions.

## Implemented

- Pins every workflow and both Action metadata paths to upstream-verified SHAs, uses contents:read by default, scopes write permissions, and disables persisted checkout credentials.
- Reuses the existing CI gates and check names. The manual release workflow defaults to non-publishing and requires exact source, signed tag, package identity and unpublished-version preflight.
- Exports the exact validated tarball with SHA256SUMS, an SPDX production SBOM, GitHub tarball attestation support and npm provenance. Release ordering stages a draft, uploads assets, publishes npm, then finalizes the release.
- Keeps the maintainer runbook separate from concise public v0.10 release notes.
- Requires a present, non-empty README inside the verified tarball. Post-publication UI readback remains separate from the registry metadata field.
- Adds Dependabot, JavaScript/TypeScript and Actions CodeQL, Dependency Review, OpenSSF Scorecard, CODEOWNERS and contribution templates.
- Documents applied repository gates, remaining release settings, verified pins, Action reproducibility and OpenSSF Passing gaps. Bundling follow-up remains in #20.

## Repository gates applied

- Dependency graph and vulnerability alerts enabled; Dependency Review passes without suppression.
- Dependabot security updates and private vulnerability reporting enabled.
- Active main-required-checks ruleset 22637595 requires a pull request, resolved conversations, an up-to-date branch and all eight CI, Dependency Review and CodeQL contexts. No bypass actors.
- Existing secret scanning, push protection, main force-push/deletion protection and release-tag protection remain enabled.

## Validation

Local release:check passed 242 tests, TypeScript build, Action contract, high-level npm audit with 0 vulnerabilities, package contents, non-empty packaged README, clean consumer installation, three CLI aliases and report contracts. SPDX/checksums and the non-publishing verified-tarball preview passed.

Final head 09f04a906e20bc20c935cbdfef38345e7d1f8de4:

- CI 34349533443 passed Node 22/24, byte-identical candidates, README commands and both Action paths.
- CodeQL 34349533421 passed JavaScript/TypeScript and Actions.
- Dependency Review 34349533418 passed after the dependency graph was enabled.

Detailed evidence is in docs/trust-hardening-validation.md.

## Deferred release gates

- Configure npm Trusted Publisher, the npm-release environment, release immutability and signing identity before the first authorized v0.10 release.
- Enable RELEASE_ENABLED only after the release checklist and dry run pass.
- OIDC authorization, actual attestation/provenance issuance and immutable-release behavior remain unproven until an authorized release.
- Scorecard public results await the first main run. Add Scorecard and OpenSSF badges only after actual results or award.
- The composite Action still resolves transitive dependencies at runtime; #20 tracks the measured bundle decision.

No credentials, npm publication, production release, tag or merge was created or changed.

## For reviewers

Confirm the public release notes stay separate from maintainer setup and recovery instructions.
