### PR TITLE
docs: qualify hosted platform pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ also accepts an empty output directory for inspecting readiness and site JSON re
 | Deterministic | Yes — versioned rules, fixture-tested | Partially | No — model output varies run to run |
 | Runs where | Local CLI, CI, pre-commit hook, Vite/Next plugins | Browser / DevTools | Vendor cloud |
 | Blocks regressions in CI | Yes, via a stable `--json` contract | Possible with extra wiring | Rarely |
-| Cost | Free, MIT | Free | Typically $95+/mo |
+| Cost | Free, MIT | Free | Varies by vendor |
 
 Visibility trackers answer "did rankings change?". geoptimize answers the question you can act on in a pull request: "is this page ready?". The two compose rather than compete.
 


### PR DESCRIPTION
## Summary
Replaces the uncited monthly price claim with vendor-dependent pricing language. This resolves the repository dogfood finding without changing scoring or runtime behavior.

## Validation
- npm test -- --run src/core/__tests__/evidence-boundaries.test.ts
- geoptimize scan README.md --json no longer reports the price-source finding

## For reviewers
Confirm the revised cost row remains useful without presenting an unsupported market statistic.

Closes #13