### PR TITLE
feat: add evidence-bound SEO rank watch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Content-readiness lint with evidence-bounded AI discovery experiments",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "geoptimize",
   "description": "Content-readiness lint and evidence-bounded discovery experiments",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Te-Shu Wang"
   },
@@ -12,6 +12,7 @@
   "commands": [
     "./skills/geo-scan/SKILL.md",
     "./skills/geo-generate/SKILL.md",
-    "./skills/geo-transform/SKILL.md"
+    "./skills/geo-transform/SKILL.md",
+    "./skills/seo-rank-watch/SKILL.md"
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           path: .github/fixtures/action-low
           min-score: '100'
-          package-spec: ./geoptimize-0.9.0.tgz
+          package-spec: ./geoptimize-0.10.0.tgz
 
       - name: Validate Action outputs
         env:
@@ -130,7 +130,7 @@ jobs:
         uses: ./
         with:
           path: examples/github-action-sample/site
-          package-spec: ./geoptimize-0.9.0.tgz
+          package-spec: ./geoptimize-0.10.0.tgz
 
       - name: Validate sample outputs
         env:
@@ -149,7 +149,7 @@ jobs:
           path: .github/fixtures/action-low
           min-score: '0'
           fail-on-low-score: 'true'
-          package-spec: ./geoptimize-0.9.0.tgz
+          package-spec: ./geoptimize-0.10.0.tgz
 
       - name: Validate blocking outputs
         env:
@@ -169,7 +169,7 @@ jobs:
           path: .github/fixtures/action-low
           min-score: '100'
           fail-on-low-score: 'true'
-          package-spec: ./geoptimize-0.9.0.tgz
+          package-spec: ./geoptimize-0.10.0.tgz
 
       - name: Invalid choice is rejected
         id: invalid-choice
@@ -178,7 +178,7 @@ jobs:
         with:
           path: .github/fixtures/action-low
           fail-on-low-score: sometimes
-          package-spec: ./geoptimize-0.9.0.tgz
+          package-spec: ./geoptimize-0.10.0.tgz
 
       - name: Out-of-range threshold is rejected
         id: invalid-threshold
@@ -187,7 +187,7 @@ jobs:
         with:
           path: .github/fixtures/action-low
           min-score: '101'
-          package-spec: ./geoptimize-0.9.0.tgz
+          package-spec: ./geoptimize-0.10.0.tgz
 
       - name: Assert expected failures
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,25 @@
 # Changelog
 
-## Unreleased — trust hardening
-
-- Prepare a SHA-pinned, least-privilege CI/security and OIDC release pipeline.
-- Export verified tarballs with checksums, SPDX SBOM and attestation support.
-- Document maintainer settings and OpenSSF gaps; preserve scoring and public contracts.
-
 All notable user-visible changes will be documented here. The project follows Semantic Versioning after the v0.6 evidence baseline is released.
+
+## 0.10.0
+
+### Added
+
+- Added `geo seo` commands for reviewable watchword, rank-history, and improvement ledgers.
+- Added fixed query-segment evidence, one-experiment-at-a-time selection, and a seven-day post-publication review cooldown.
+- Added a reusable SEO rank-watch skill and workflow documentation.
+
+### Compatibility
+
+- Kept the deterministic content-readiness score and existing audit JSON contracts unchanged.
+- Kept Search Console authentication and search-result collection outside the CLI; observations remain explicit user-supplied evidence.
+
+### Security
+
+- Added a SHA-pinned, least-privilege CI and OIDC release pipeline.
+- Added verified tarball export with checksums, an SPDX SBOM, and attestation support.
+- Documented maintainer settings, release recovery, and current OpenSSF gaps.
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ npx skills add cucuwang/geoptimize
 - `/geo-scan` — deterministic readiness audit with optional experimental review
 - `/geo-generate` — preview optional discovery artifacts
 - `/geo-transform` — propose content edits without inventing claims
+- `/seo-rank-watch` — run one evidence-bounded Search Console ranking experiment
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ geo seo add . --keyword "energy management system integration" --page /services/
 geo seo status .
 ```
 
-The ledger enforces one active page experiment and a seven-day cooldown while preserving fixed query, page, country, device, search type, and date-window evidence. It does not affect the readiness score. See [SEO rank watch](docs/seo-rank-watch.md).
+The ledger enforces one active page experiment and a seven-day cooldown while preserving fixed query, page, country, device, search type, and date-window evidence. Start the cooldown only after the changed page is publicly deployed and read back. The ledger does not affect the readiness score. See [SEO rank watch](docs/seo-rank-watch.md).
 
 Example output:
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ node -e "const r=require('./geoptimize-report.json'); process.exit(r.overall.tot
 The [GitHub Marketplace Action](https://github.com/marketplace/actions/geoptimize-content-readiness-check) is advisory by default. It reports findings without blocking the workflow:
 
 ```yaml
-- uses: cucuwang/geoptimize@v0.9.0
+- uses: cucuwang/geoptimize@v0.10.0
   with:
     path: dist
 ```
@@ -205,7 +205,7 @@ The [GitHub Marketplace Action](https://github.com/marketplace/actions/geoptimiz
 Projects can explicitly choose blocking mode after accepting a baseline:
 
 ```yaml
-- uses: cucuwang/geoptimize@v0.9.0
+- uses: cucuwang/geoptimize@v0.10.0
   with:
     path: dist
     fail-on-low-score: 'true'
@@ -327,7 +327,7 @@ npx skills add cucuwang/geoptimize
 
 ## Project status
 
-Version 0.9 adds site metrics, offline visual reports, detailed rule evidence and baseline comparisons while retaining the existing scoring contract. Release acceptance and rollback are documented in [docs/release-v0.9.md](docs/release-v0.9.md); longer-term adoption work remains in [ROADMAP.md](ROADMAP.md).
+Version 0.10 adds a separate, evidence-bounded SEO rank-watch ledger while retaining the existing readiness score and audit contracts. Release acceptance and rollback are documented in [docs/release-v0.10.md](docs/release-v0.10.md); longer-term adoption work remains in [ROADMAP.md](ROADMAP.md).
 
 Contributions are welcome. Rule changes require an evidence note and positive/negative fixtures; see [CONTRIBUTING.md](CONTRIBUTING.md). Report vulnerabilities through the process in [SECURITY.md](SECURITY.md).
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ npx geoptimize audit https://example.com --json
 npx geoptimize audit-site https://example.com --max-pages 20 --json
 ```
 
+For measured Google Search experiments, initialize the separate SEO ledger:
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+The ledger enforces one active page experiment and a seven-day cooldown while preserving fixed query, page, country, device, search type, and date-window evidence. It does not affect the readiness score. See [SEO rank watch](docs/seo-rank-watch.md).
+
 Example output:
 
 ```text

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   package-spec:
     description: npm package spec to install; keep the default outside prerelease testing
     required: false
-    default: 'geoptimize@0.9.0'
+    default: 'geoptimize@0.10.0'
 
 outputs:
   score:

--- a/action/action.yml
+++ b/action/action.yml
@@ -20,7 +20,7 @@ inputs:
   package-spec:
     description: npm package spec to install; keep the default outside prerelease testing
     required: false
-    default: 'geoptimize@0.9.0'
+    default: 'geoptimize@0.10.0'
 
 outputs:
   score:

--- a/docs/release-notes-v0.10.md
+++ b/docs/release-notes-v0.10.md
@@ -1,5 +1,12 @@
 # geoptimize 0.10.0
 
+## SEO rank watch
+
+- Adds `geo seo` commands for reviewable watchword, rank-history, and improvement ledgers.
+- Keeps one page experiment observing at a time and starts its seven-day cooldown only after public deployment.
+- Preserves fixed query, page, country, device, search type, and date-window evidence for later review.
+- Includes the reusable `/seo-rank-watch` skill and workflow guide.
+
 ## Release integrity
 
 - Publishes the exact tarball validated by CI on Node.js 22 and 24.
@@ -9,7 +16,7 @@
 
 ## Compatibility
 
-Scoring, CLI, API, JSON output and composite Action contracts remain unchanged.
+The readiness score, existing audit JSON output, and composite Action scoring contracts remain unchanged.
 
 ## Install
 

--- a/docs/release-v0.10.md
+++ b/docs/release-v0.10.md
@@ -1,16 +1,18 @@
 # v0.10 trust-hardening release runbook
 
-Status: repository preparation; package version remains 0.9.0 until an approved
-version-bump PR. Nothing in this document asserts that 0.10.0 has been published.
-Scoring, CLI/API/JSON and composite Action contracts remain unchanged.
+Status: release candidate preparation; package version 0.10.0 is under review.
+Nothing in this document asserts that 0.10.0 has been published. This release
+adds the `geo seo` CLI, API, data contract, and skill while preserving the
+readiness score, existing audit JSON, and composite Action scoring contracts.
 
 ## Candidate and dry run
 
 The reusable CI workflow remains the single acceptance pipeline. On both Node 22
 and 24 it runs `npm ci` and `npm run release:check`: clean worktree, tests, TypeScript,
 Action shell contract, high/critical npm audit gate, package contents, clean consumer
-installation, all three aliases and report contracts. Separate jobs exercise the
-actual composite Action, README commands and byte-identical Node candidate manifests.
+installation, all three aliases, report contracts, and the clean-install SEO
+workflow. Separate jobs exercise the actual composite Action, README commands,
+and byte-identical Node candidate manifests.
 
 The verifier can export its already-tested tarball via `RELEASE_TARBALL_OUT`; it never
 re-packs for publication. Node 24 prepares a production SPDX 2.3 SBOM, SHA256SUMS and
@@ -48,9 +50,9 @@ not external npm authorization or immutable-release settings.
 
 1. Complete [maintainer settings](maintainer-security-settings.md), including npm
    environment binding, main required checks, immutable releases and signing identity.
-2. Prepare a separate version-bump PR updating package/lock, CLI and plugin metadata,
-   both Action defaults, sample pins, hard-coded CI tarball fixtures, changelog and
-   release-contract expectations. Run all gates. Do not rewrite v0.9.0.
+2. Review the version-bump PR that updates package/lock, CLI and plugin metadata,
+   both Action defaults, sample pins, hard-coded CI tarball fixtures, changelog,
+   the SEO workflow, and release-contract expectations. Run all gates. Preserve v0.9.0.
 3. Merge the approved release commit, fetch origin/main, and ensure it is still main's
    exact HEAD. With explicit release authorization, create an annotated signed tag
    (`git tag -s v0.10.0 <commit> -m 'geoptimize 0.10.0'`) and push only that tag.
@@ -90,7 +92,7 @@ References: [npm SBOM](https://docs.npmjs.com/cli/v11/commands/npm-sbom/),
 [GitHub attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations),
 [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
 
-## Recovery
+## Rollback and recovery
 
 Publication crosses two services and cannot be atomic. If draft staging succeeds but
 npm fails, leave the draft and inspect logs; do not finalize it. If npm succeeds and
@@ -101,3 +103,17 @@ Never overwrite assets on a finalized release or retag an existing version. Depr
 or adjust dist-tags only with authorization, preserving audit evidence and fixing
 forward. An advanced main branch requires a new release decision, not bypassing the
 exact-main source gate.
+
+Public readback requires the release commit and verified candidate hash:
+
+```bash
+bash scripts/verify-release-v0.8.sh <verified-release-commit> <verified-package-sha256>
+```
+
+If rollback is authorized, preserve the published version and protected tag,
+restore 0.9.0 as the default, and deprecate 0.10.0 while preparing a corrective release:
+
+```bash
+npm dist-tag add geoptimize@0.9.0 latest
+npm deprecate geoptimize@0.10.0 "Use 0.9.0 while a corrective release is prepared."
+```

--- a/docs/seo-rank-watch.md
+++ b/docs/seo-rank-watch.md
@@ -48,12 +48,13 @@ Select one candidate, compare the target page with current leading results, defi
 geo seo select .
 geo seo start . \
   --keyword "能源管理系統整合" \
+  --date 2026-09-11 \
   --intent "A facilities manager is comparing what an EMS integration includes and whether existing devices can remain." \
   --gap "The page explains architecture but does not answer implementation scope near the main content." \
   --change "Added a visible implementation-scope section and direct links to system evidence."
 ```
 
-`start` allows only the selected query and moves it to `observing` for seven days. While one query is observing, another experiment cannot start in that repository.
+Deploy the page, read the public URL back, and then call `start` with the verified publication date. `start` allows only the selected query and moves it to `observing` for seven days. A local commit, preview, or green build does not start the cooldown. While one query is observing, another experiment cannot start in that repository.
 
 After the cooldown, record a comparable seven-day Search Console observation and review it:
 
@@ -73,4 +74,4 @@ geo seo review . \
 - Keep the query, page, country, device, search type, and date window fixed when comparing observations.
 - Add information that satisfies the search need. Do not pad the page or repeat keywords mechanically.
 - Treat `noindex`, canonical changes, redirects, and large information-architecture changes as separate reviewed changes.
-- Report the implemented change and measured outcome separately. A readiness score change is not ranking evidence.
+- Report the local implementation, public deployment, and measured outcome separately. A readiness score change is not ranking evidence.

--- a/docs/seo-rank-watch.md
+++ b/docs/seo-rank-watch.md
@@ -1,0 +1,76 @@
+# SEO rank watch
+
+`geo seo` keeps ranking experiments separate from geoptimize's deterministic content-readiness score. It records what was observed, which single query was changed, and whether a comparable post-change measurement moved. It does not scrape Google, authenticate to Search Console, or predict ranking.
+
+## Data contract
+
+Initialize three reviewable files in a website repository:
+
+```bash
+geo seo init .
+```
+
+- `data/seo/watchwords.json` stores exact queries, target pages, priorities, and experiment status.
+- `data/seo/rank-history.json` is append-only measurement history.
+- `data/seo/improvement-log.json` stores search intent, the observed content gap, the completed change, the seven-day review date, and review outcomes.
+
+Commit these files with the page change. Never commit Search Console credentials, cookies, OAuth tokens, or service-account keys.
+
+## Workflow
+
+Add exact query and page pairs. Keep brand queries separate from service queries.
+
+```bash
+geo seo add . --keyword "能源管理系統整合" --page /platform/ --priority high
+```
+
+Record a fixed Search Console segment. The date window, country, device, and search type are required so later observations can be compared honestly.
+
+```bash
+geo seo record . \
+  --keyword "能源管理系統整合" \
+  --page /platform/ \
+  --source gsc \
+  --start-date 2026-08-13 \
+  --end-date 2026-09-09 \
+  --country TWN \
+  --device DESKTOP \
+  --position 7.2 \
+  --impressions 41 \
+  --clicks 2
+```
+
+Use `--source serp` only for an observed organic result. Keep its country, device, and one-day window explicit. A missing position with zero impressions is recorded as `null`; it is not labeled unindexed.
+
+Select one candidate, compare the target page with current leading results, define the searcher's need, and make one focused page change.
+
+```bash
+geo seo select .
+geo seo start . \
+  --keyword "能源管理系統整合" \
+  --intent "A facilities manager is comparing what an EMS integration includes and whether existing devices can remain." \
+  --gap "The page explains architecture but does not answer implementation scope near the main content." \
+  --change "Added a visible implementation-scope section and direct links to system evidence."
+```
+
+`start` allows only the selected query and moves it to `observing` for seven days. While one query is observing, another experiment cannot start in that repository.
+
+After the cooldown, record a comparable seven-day Search Console observation and review it:
+
+```bash
+geo seo review . \
+  --keyword "能源管理系統整合" \
+  --outcome improved \
+  --observation 0123456789abcdef \
+  --note "The same TWN desktop segment moved from 7.2 to 4.8."
+```
+
+`achieved` ends active changes for the query. Other outcomes return it to `active`; the next action should test a different content gap. Use adjacent complete 28-day windows for trend reporting and a post-change seven-day window for the scheduled review. Search Console average position remains an aggregate, not a universal live rank.
+
+## Guardrails
+
+- Use Search Console as the primary performance source. Do not automate Google result scraping.
+- Keep the query, page, country, device, search type, and date window fixed when comparing observations.
+- Add information that satisfies the search need. Do not pad the page or repeat keywords mechanically.
+- Treat `noindex`, canonical changes, redirects, and large information-architecture changes as separate reviewed changes.
+- Report the implemented change and measured outcome separately. A readiness score change is not ranking evidence.

--- a/examples/github-action-sample/.github/workflows/geoptimize.yml
+++ b/examples/github-action-sample/.github/workflows/geoptimize.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cucuwang/geoptimize@v0.9.0
+      - uses: cucuwang/geoptimize@v0.10.0
         with:
           path: site
           fail-on-low-score: 'false'

--- a/examples/github-action-sample/README.md
+++ b/examples/github-action-sample/README.md
@@ -6,4 +6,4 @@ This directory is a copyable end-to-end sample for the v0.6 Action contract.
 - `site/index.html` is a deterministic public input.
 - The Action is advisory by default. The sample does not block a pull request on an unreviewed score threshold.
 
-The workflow becomes reproducible only after both `geoptimize@0.9.0` exists on npm and the immutable `v0.9.0` Git tag points to the matching release commit. Until both artifacts exist, use the local CLI or the release-candidate package during controlled verification.
+The workflow becomes reproducible only after both `geoptimize@0.10.0` exists on npm and the immutable `v0.10.0` Git tag points to the matching release commit. Until both artifacts exist, use the local CLI or the release-candidate package during controlled verification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geoptimize",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geoptimize",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoptimize",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Deterministic content-readiness lint for static websites and documentation",
   "type": "module",
   "main": "./dist/core/index.js",
@@ -36,10 +36,10 @@
     "docs/release-v0.8.md",
     "scripts/verify-release-v0.8.sh",
     "docs/release-v0.9.md",
+    "docs/release-v0.10.md",
     "docs/visual-report.md",
     "docs/seo-rank-watch.md",
     "docs/assets/",
-    "docs/release-v0.10.md",
     "docs/maintainer-security-settings.md",
     "docs/openssf-best-practices.md",
     "docs/action-reproducibility.md"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "scripts/verify-release-v0.8.sh",
     "docs/release-v0.9.md",
     "docs/visual-report.md",
+    "docs/seo-rank-watch.md",
     "docs/assets/",
     "docs/release-v0.10.md",
     "docs/maintainer-security-settings.md",

--- a/scripts/verify-release-candidate.sh
+++ b/scripts/verify-release-candidate.sh
@@ -64,6 +64,7 @@ jq -e '
   (.[0].files | map(.path) | index("dist/core/visual-report.js")) != null and
   (.[0].files | map(.path) | index("dist/core/readiness-comparison.js")) != null and
   (.[0].files | map(.path) | index("docs/release-v0.9.md")) != null and
+  (.[0].files | map(.path) | index("docs/release-v0.10.md")) != null and
   (.[0].files | map(.path) | index("docs/assets/report-demo.html")) != null and
   (.[0].files | map(.path) | index("docs/assets/report-demo-after.html")) != null and
   (.[0].files | map(.path) | index("docs/release-v0.8.md")) != null and

--- a/scripts/verify-release-candidate.sh
+++ b/scripts/verify-release-candidate.sh
@@ -63,8 +63,11 @@ jq -e '
   (.[0].files | map(.path) | index("dist/core/site-metrics.js")) != null and
   (.[0].files | map(.path) | index("dist/core/visual-report.js")) != null and
   (.[0].files | map(.path) | index("dist/core/readiness-comparison.js")) != null and
+  (.[0].files | map(.path) | index("dist/core/seo-watch.js")) != null and
   (.[0].files | map(.path) | index("docs/release-v0.9.md")) != null and
   (.[0].files | map(.path) | index("docs/release-v0.10.md")) != null and
+  (.[0].files | map(.path) | index("docs/seo-rank-watch.md")) != null and
+  (.[0].files | map(.path) | index("skills/seo-rank-watch/SKILL.md")) != null and
   (.[0].files | map(.path) | index("docs/assets/report-demo.html")) != null and
   (.[0].files | map(.path) | index("docs/assets/report-demo-after.html")) != null and
   (.[0].files | map(.path) | index("docs/release-v0.8.md")) != null and
@@ -95,6 +98,42 @@ done
 for audit_command in audit audit-build audit-site metrics report; do
   "$CONSUMER_ROOT/node_modules/.bin/geoptimize" "$audit_command" --help >/dev/null
 done
+
+SEO_ROOT="$VERIFY_ROOT/seo-ledger"
+GEO_BINARY="$CONSUMER_ROOT/node_modules/.bin/geo"
+SEO_KEYWORD="release acceptance keyword"
+mkdir -p "$SEO_ROOT"
+"$GEO_BINARY" seo init "$SEO_ROOT" >/dev/null
+"$GEO_BINARY" seo add "$SEO_ROOT" \
+  --keyword "$SEO_KEYWORD" --page /services/ems/ --priority high >/dev/null
+"$GEO_BINARY" seo record "$SEO_ROOT" \
+  --keyword "$SEO_KEYWORD" --page /services/ems/ --source gsc \
+  --start-date 2025-12-01 --end-date 2025-12-28 \
+  --country TWN --device DESKTOP --position 9 --clicks 1 --impressions 20 \
+  --observed-at 2025-12-29T00:00:00Z >/dev/null
+"$GEO_BINARY" seo select "$SEO_ROOT" --json > "$VERIFY_ROOT/seo-candidate.json"
+jq -e --arg keyword "$SEO_KEYWORD" '.watchword.keyword == $keyword' \
+  "$VERIFY_ROOT/seo-candidate.json" >/dev/null
+"$GEO_BINARY" seo start "$SEO_ROOT" \
+  --keyword "$SEO_KEYWORD" --date 2026-01-01 \
+  --intent "Compare an EMS integration scope" \
+  --gap "The page lacks visible inputs and outputs" \
+  --change "Added visible inputs and outputs" >/dev/null
+"$GEO_BINARY" seo record "$SEO_ROOT" \
+  --keyword "$SEO_KEYWORD" --page /services/ems/ --source gsc \
+  --start-date 2026-01-02 --end-date 2026-01-08 \
+  --country TWN --device DESKTOP --position 6 --clicks 2 --impressions 28 \
+  --observed-at 2026-01-09T00:00:00Z > "$VERIFY_ROOT/seo-observation.json"
+SEO_OBSERVATION_ID=$(jq -er '.id' "$VERIFY_ROOT/seo-observation.json")
+"$GEO_BINARY" seo review "$SEO_ROOT" \
+  --keyword "$SEO_KEYWORD" --outcome improved \
+  --observation "$SEO_OBSERVATION_ID" --date 2026-01-08 \
+  --note "Comparable release acceptance observation" >/dev/null
+"$GEO_BINARY" seo status "$SEO_ROOT" --json > "$VERIFY_ROOT/seo-status.json"
+jq -e --arg keyword "$SEO_KEYWORD" '
+  .counts == {active: 1, observing: 0, achieved: 0, observations: 2} and
+  .candidate.watchword.keyword == $keyword
+' "$VERIFY_ROOT/seo-status.json" >/dev/null
 
 "$CONSUMER_ROOT/node_modules/.bin/geoptimize" audit \
   "$CONSUMER_ROOT/node_modules/geoptimize/examples/github-action-sample/site/index.html" \

--- a/skills/seo-rank-watch/SKILL.md
+++ b/skills/seo-rank-watch/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: seo-rank-watch
+description: Use when maintaining a measured Google Search ranking experiment with one keyword, one target page, and a seven-day cooldown
+---
+
+# SEO Rank Watch
+
+Use geoptimize's SEO ledger for a controlled ranking experiment. This workflow is separate from GEO readiness scoring and does not promise a ranking outcome.
+
+## Workflow
+
+1. Run `geo seo status <repository>` and read all three `data/seo` files.
+2. Record a fixed Search Console observation with `geo seo record`. Prefer the exact query plus page, country, device, search type, and complete date window. Use an observed web result only when current SERP context is needed.
+3. Review an `observing` query only when `nextReviewDate` is due. Use a comparable post-action observation and `geo seo review`.
+4. Run `geo seo select <repository>`. Improve only the returned keyword. If it returns no candidate, report the state and stop.
+5. Define in one or two sentences who searched and what they need. Inspect current leading pages and identify one information gap on the target page.
+6. Make one focused improvement that answers the need. Internal links should lead to the visitor's likely next question or action.
+7. Run the site's normal tests and a geoptimize build audit. Then call `geo seo start` with the exact intent, gap, and completed change.
+8. Commit the page change and `data/seo` files together. Report the next review date without predicting the outcome.
+
+## Boundaries
+
+- Do not scrape Google result pages with a custom script.
+- Do not reinterpret `position: null` and zero impressions as proof that a page is unindexed.
+- Do not modify another keyword while one is `observing`.
+- Do not change `noindex`, canonicals, redirects, or major site structure without explicit review of the exact scope.
+- Do not overwrite or edit earlier rank-history entries.
+- Do not output or commit credentials, tokens, cookies, or service-account keys.
+- Do not describe a geoptimize score increase as ranking evidence.

--- a/skills/seo-rank-watch/SKILL.md
+++ b/skills/seo-rank-watch/SKILL.md
@@ -15,8 +15,8 @@ Use geoptimize's SEO ledger for a controlled ranking experiment. This workflow i
 4. Run `geo seo select <repository>`. Improve only the returned keyword. If it returns no candidate, report the state and stop.
 5. Define in one or two sentences who searched and what they need. Inspect current leading pages and identify one information gap on the target page.
 6. Make one focused improvement that answers the need. Internal links should lead to the visitor's likely next question or action.
-7. Run the site's normal tests and a geoptimize build audit. Then call `geo seo start` with the exact intent, gap, and completed change.
-8. Commit the page change and `data/seo` files together. Report the next review date without predicting the outcome.
+7. Run the site's normal tests and a geoptimize build audit. Commit the page change and baseline `data/seo` files together without starting the cooldown.
+8. After deployment, read the public page and deployment marker back. Then call `geo seo start` with the verified publication date, exact intent, gap, and completed change. Commit the ledger update and report the next review date without predicting the outcome.
 
 ## Boundaries
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -449,12 +449,12 @@ seoCmd
 
 seoCmd
   .command('start <repository>')
-  .description('Record one completed page improvement and begin its seven-day cooldown')
+  .description('Record one publicly deployed page improvement and begin its seven-day cooldown')
   .requiredOption('--keyword <text>', 'The currently selected exact query')
   .requiredOption('--intent <text>', 'Who searched and what they needed')
   .requiredOption('--gap <text>', 'Observed gap against that need')
   .requiredOption('--change <text>', 'Specific completed page change')
-  .option('--date <date>', 'Action date, YYYY-MM-DD')
+  .option('--date <date>', 'Verified publication date, YYYY-MM-DD')
   .action(async (repository: string, options: { keyword: string; intent: string; gap: string; change: string; date?: string }) => {
     try {
       const experiment = await startSeoExperiment(repository, {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name('geoptimize')
   .description('Deterministic content-readiness lint for websites and documentation')
-  .version('0.9.0');
+  .version('0.10.0');
 
 // ── scan command ───────────────────────────────────────────────────
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,19 @@ import { generate } from '../core/generator.js';
 import { detectAvailableCLIs, scoreWithAllAvailable } from '../core/external-scorers.js';
 import { mergeScores } from '../core/merger.js';
 import { auditPath } from '../core/static-audit.js';
+import {
+  addSeoWatchword,
+  initializeSeoWatch,
+  loadSeoWatch,
+  recordSeoRank,
+  reviewSeoExperiment,
+  selectSeoCandidate,
+  startSeoExperiment,
+  summarizeSeoWatch,
+  type SeoPriority,
+  type SeoRankSource,
+  type SeoReviewOutcome,
+} from '../core/seo-watch.js';
 import type { AuditReport, AuditStatus, SiteAuditReport, ScanReport, MultiAiReport, DimensionScores, ScanTarget, SiteInfo, AiScorerResult } from '../core/types.js';
 
 const HOOK_BEGIN_MARKER = '# BEGIN geoptimize';
@@ -334,6 +347,174 @@ program
     }
   });
 
+// ── seo command ───────────────────────────────────────────────────
+
+const seoCmd = program
+  .command('seo')
+  .description('Track evidence-bounded SEO ranking experiments without changing readiness scores');
+
+seoCmd
+  .command('init <repository>')
+  .description('Create data/seo watchword, rank-history, and improvement-log files')
+  .action(async (repository: string) => {
+    try {
+      await initializeSeoWatch(repository);
+      console.log(`SEO watch initialized in ${join(repository, 'data', 'seo')}`);
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+seoCmd
+  .command('add <repository>')
+  .description('Add one keyword and target page to the watchlist')
+  .requiredOption('--keyword <text>', 'Exact query to track')
+  .requiredOption('--page <path>', 'Target path or canonical URL')
+  .option('--priority <priority>', 'high, medium, or low', 'medium')
+  .action(async (repository: string, options: { keyword: string; page: string; priority: SeoPriority }) => {
+    try {
+      const watchword = await addSeoWatchword(repository, {
+        keyword: options.keyword, targetPath: options.page, priority: options.priority,
+      });
+      console.log(JSON.stringify(watchword, null, 2));
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+seoCmd
+  .command('record <repository>')
+  .description('Append one fixed-window GSC or observed SERP ranking measurement')
+  .requiredOption('--keyword <text>', 'Exact query')
+  .requiredOption('--page <path>', 'Target path or canonical URL')
+  .requiredOption('--source <source>', 'gsc or serp')
+  .requiredOption('--start-date <date>', 'Measurement start date, YYYY-MM-DD')
+  .requiredOption('--end-date <date>', 'Measurement end date, YYYY-MM-DD')
+  .requiredOption('--country <country>', 'Fixed country segment, such as TWN')
+  .requiredOption('--device <device>', 'Fixed device segment, such as DESKTOP')
+  .option('--search-type <type>', 'Search type segment', 'web')
+  .option('--position <number>', 'Average GSC position or observed organic result position')
+  .option('--clicks <number>', 'GSC clicks')
+  .option('--impressions <number>', 'GSC impressions')
+  .option('--observed-at <timestamp>', 'ISO timestamp for the observation')
+  .action(async (repository: string, options: {
+    keyword: string; page: string; source: SeoRankSource; startDate: string; endDate: string;
+    country: string; device: string; searchType: string; position?: string; clicks?: string;
+    impressions?: string; observedAt?: string;
+  }) => {
+    try {
+      const observation = await recordSeoRank(repository, {
+        keyword: options.keyword,
+        targetPath: options.page,
+        source: options.source,
+        startDate: options.startDate,
+        endDate: options.endDate,
+        country: options.country,
+        device: options.device,
+        searchType: options.searchType,
+        position: optionalNumber(options.position, 'position'),
+        clicks: optionalNumber(options.clicks, 'clicks'),
+        impressions: optionalNumber(options.impressions, 'impressions'),
+        observedAt: options.observedAt,
+      });
+      console.log(JSON.stringify(observation, null, 2));
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+seoCmd
+  .command('select <repository>')
+  .description('Select exactly one eligible keyword using recorded evidence and priority')
+  .option('--json', 'Output JSON')
+  .action(async (repository: string, options: { json?: boolean }) => {
+    try {
+      const candidate = selectSeoCandidate(await loadSeoWatch(repository));
+      if (options.json) {
+        console.log(JSON.stringify(candidate, null, 2));
+      } else if (!candidate) {
+        console.log('No keyword selected. An experiment may be observing, every watchword may be achieved, or the watchlist may be empty.');
+      } else {
+        console.log(`${candidate.watchword.keyword} -> ${candidate.watchword.targetPath}`);
+        console.log(candidate.reason);
+      }
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+seoCmd
+  .command('start <repository>')
+  .description('Record one completed page improvement and begin its seven-day cooldown')
+  .requiredOption('--keyword <text>', 'The currently selected exact query')
+  .requiredOption('--intent <text>', 'Who searched and what they needed')
+  .requiredOption('--gap <text>', 'Observed gap against that need')
+  .requiredOption('--change <text>', 'Specific completed page change')
+  .option('--date <date>', 'Action date, YYYY-MM-DD')
+  .action(async (repository: string, options: { keyword: string; intent: string; gap: string; change: string; date?: string }) => {
+    try {
+      const experiment = await startSeoExperiment(repository, {
+        keyword: options.keyword,
+        searchIntent: options.intent,
+        gap: options.gap,
+        change: options.change,
+        date: options.date,
+      });
+      console.log(JSON.stringify(experiment, null, 2));
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+seoCmd
+  .command('review <repository>')
+  .description('Review a due experiment against a matching post-action observation')
+  .requiredOption('--keyword <text>', 'Exact query under review')
+  .requiredOption('--outcome <outcome>', 'achieved, improved, unchanged, or declined')
+  .requiredOption('--observation <id>', 'Matching rank-history observation ID')
+  .option('--note <text>', 'Short evidence note')
+  .option('--date <date>', 'Review date, YYYY-MM-DD')
+  .action(async (repository: string, options: { keyword: string; outcome: SeoReviewOutcome; observation: string; note?: string; date?: string }) => {
+    try {
+      const experiment = await reviewSeoExperiment(repository, {
+        keyword: options.keyword,
+        outcome: options.outcome,
+        observationId: options.observation,
+        note: options.note,
+        date: options.date,
+      });
+      console.log(JSON.stringify(experiment, null, 2));
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+seoCmd
+  .command('status <repository>')
+  .description('Summarize active, observing, and achieved SEO experiments')
+  .option('--json', 'Output JSON')
+  .action(async (repository: string, options: { json?: boolean }) => {
+    try {
+      const summary = summarizeSeoWatch(await loadSeoWatch(repository));
+      if (options.json) {
+        console.log(JSON.stringify(summary, null, 2));
+      } else {
+        console.log(`Active ${summary.counts.active} | Observing ${summary.counts.observing} | Achieved ${summary.counts.achieved} | Observations ${summary.counts.observations}`);
+        if (summary.candidate) console.log(`Next candidate: ${summary.candidate.watchword.keyword} -> ${summary.candidate.watchword.targetPath}`);
+        for (const item of summary.observing) console.log(`Observing: ${item.keyword} until ${item.nextReviewDate}`);
+      }
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
 // ── hook command ──────────────────────────────────────────────────
 
 const hookCmd = program
@@ -519,6 +700,13 @@ function resolveTarget(target: string, isDir?: boolean): ScanTarget {
   }
   // Fallback: assume URL with https
   return { type: 'url', path: `https://${target}` };
+}
+
+function optionalNumber(value: string | undefined, label: string): number | null {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${label} must be a number.`);
+  return parsed;
 }
 
 function detectSiteName(dir: string, report: ScanReport): string {

--- a/src/core/__tests__/evidence-boundaries.test.ts
+++ b/src/core/__tests__/evidence-boundaries.test.ts
@@ -75,7 +75,7 @@ describe('public metadata', () => {
     expect(publicSurface).toContain('cucuwang/geoptimize');
   });
 
-  it('keeps v0.6 package, CLI, plugin, and Action versions aligned', async () => {
+  it('keeps package, CLI, plugin, and Action versions aligned', async () => {
     const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
     const pluginJson = JSON.parse(await readFile(join(root, '.claude-plugin/plugin.json'), 'utf8'));
     const marketplaceJson = JSON.parse(await readFile(join(root, '.claude-plugin/marketplace.json'), 'utf8'));
@@ -83,7 +83,7 @@ describe('public metadata', () => {
     const action = await readFile(join(root, 'action.yml'), 'utf8');
     const compatibilityAction = await readFile(join(root, 'action/action.yml'), 'utf8');
 
-    expect(packageJson.version).toBe('0.9.0');
+    expect(packageJson.version).toBe('0.10.0');
     expect(pluginJson.version).toBe(packageJson.version);
     expect(marketplaceJson.metadata.version).toBe(packageJson.version);
     expect(cli).toContain(`.version('${packageJson.version}')`);
@@ -92,6 +92,7 @@ describe('public metadata', () => {
     expect(action).toContain("default: 'false'");
     expect(compatibilityAction).toContain(`default: 'geoptimize@${packageJson.version}'`);
     expect(compatibilityAction).toContain("default: 'false'");
+    expect(pluginJson.commands).toContain('./skills/seo-rank-watch/SKILL.md');
   });
 
   it('keeps npm publisher metadata normalized and exposes every CLI alias', async () => {

--- a/src/core/__tests__/release-contract.test.ts
+++ b/src/core/__tests__/release-contract.test.ts
@@ -178,11 +178,13 @@ describe('v0.6 JSON automation contract', () => {
 
   it('ships release and rollback instructions with the package', async () => {
     const packageJson = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8'));
-    const releaseGuide = await readFile(join(repositoryRoot, 'docs/release-v0.9.md'), 'utf8');
+    const releaseLine = packageJson.version.split('.').slice(0, 2).join('.');
+    const releaseGuidePath = `docs/release-v${releaseLine}.md`;
+    const releaseGuide = await readFile(join(repositoryRoot, releaseGuidePath), 'utf8');
     const candidateVerifier = await readFile(join(repositoryRoot, 'scripts/verify-release-candidate.sh'), 'utf8');
     const publicVerifier = await readFile(join(repositoryRoot, 'scripts/verify-release-v0.8.sh'), 'utf8');
 
-    expect(packageJson.files).toContain('docs/release-v0.9.md');
+    expect(packageJson.files).toContain(releaseGuidePath);
     expect(packageJson.files).toContain('docs/visual-report.md');
     expect(packageJson.files).toContain('docs/assets/');
     expect(packageJson.files).toContain('fixtures/');
@@ -195,7 +197,7 @@ describe('v0.6 JSON automation contract', () => {
       'npm run release:check && bash scripts/verify-publish-source.sh',
     );
     expect(releaseGuide).toContain('## Rollback');
-    expect(releaseGuide).toContain('npm dist-tag add geoptimize@0.8.0 latest');
+    expect(releaseGuide).toContain('npm dist-tag add geoptimize@0.9.0 latest');
     expect(releaseGuide).toContain('<verified-package-sha256>');
     expect(candidateVerifier).toContain('index("README.md")');
     expect(candidateVerifier).toContain('tar -xOf "$PACKAGE_TARBALL" package/README.md');
@@ -215,6 +217,6 @@ describe('v0.6 JSON automation contract', () => {
     expect(workflow).not.toContain('--notes-file docs/release-v0.10.md');
     expect(releaseNotes).toContain('# geoptimize 0.10.0');
     expect(releaseNotes).not.toContain('repository preparation');
-    expect(runbook).toContain('Status: repository preparation');
+    expect(runbook).toContain('Status: release candidate preparation');
   });
 });

--- a/src/core/__tests__/release-verifier.test.ts
+++ b/src/core/__tests__/release-verifier.test.ts
@@ -9,8 +9,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = join(testDirectory, '../../..');
 const verifier = join(repositoryRoot, 'scripts/verify-release-v0.8.sh');
+const expectedVersion = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8')).version as string;
 const expectedCommit = '0123456789abcdef0123456789abcdef01234567';
-const tarballContent = 'verified geoptimize v0.9.0 candidate';
+const tarballContent = `verified geoptimize v${expectedVersion} candidate`;
 const expectedTarballHash = createHash('sha256').update(tarballContent).digest('hex');
 
 interface CommandResult {
@@ -29,7 +30,7 @@ function runVerifier(
       env: {
         ...process.env,
         PATH: `${mockBin}:${process.env.PATH}`,
-        MOCK_LATEST: '0.9.0',
+        MOCK_LATEST: expectedVersion,
         MOCK_NPM_GIT_HEAD: expectedCommit,
         MOCK_REPOSITORY_URL: 'git+https://github.com/cucuwang/geoptimize.git',
         MOCK_TAG_COMMIT: expectedCommit,
@@ -80,13 +81,13 @@ done
 
 case "$url" in
   https://registry.npmjs.org/geoptimize)
-    printf '{"dist-tags":{"latest":"%s"},"versions":{"0.9.0":{"gitHead":"%s","repository":{"url":"%s"},"homepage":"https://github.com/cucuwang/geoptimize","bugs":{"url":"https://github.com/cucuwang/geoptimize/issues"},"dist":{"tarball":"https://registry.npmjs.org/geoptimize/-/geoptimize-0.9.0.tgz"}}}}' "$MOCK_LATEST" "$MOCK_NPM_GIT_HEAD" "$MOCK_REPOSITORY_URL"
+    printf '{"dist-tags":{"latest":"%s"},"versions":{"${expectedVersion}":{"gitHead":"%s","repository":{"url":"%s"},"homepage":"https://github.com/cucuwang/geoptimize","bugs":{"url":"https://github.com/cucuwang/geoptimize/issues"},"dist":{"tarball":"https://registry.npmjs.org/geoptimize/-/geoptimize-${expectedVersion}.tgz"}}}}' "$MOCK_LATEST" "$MOCK_NPM_GIT_HEAD" "$MOCK_REPOSITORY_URL"
     ;;
-  https://registry.npmjs.org/geoptimize/-/geoptimize-0.9.0.tgz)
+  https://registry.npmjs.org/geoptimize/-/geoptimize-${expectedVersion}.tgz)
     printf '%s' "$MOCK_TARBALL_CONTENT" > "$output_file"
     ;;
-  https://api.github.com/repos/cucuwang/geoptimize/releases/tags/v0.9.0)
-    printf '{"tag_name":"v0.9.0","draft":%s,"prerelease":%s}' "$MOCK_RELEASE_DRAFT" "$MOCK_RELEASE_PRERELEASE" > "$output_file"
+  https://api.github.com/repos/cucuwang/geoptimize/releases/tags/v${expectedVersion})
+    printf '{"tag_name":"v${expectedVersion}","draft":%s,"prerelease":%s}' "$MOCK_RELEASE_DRAFT" "$MOCK_RELEASE_PRERELEASE" > "$output_file"
     printf '200'
     ;;
   *)
@@ -98,7 +99,7 @@ esac
 
     await writeExecutable(join(mockBin, 'git'), `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\trefs/tags/v0.9.0\n' "$MOCK_TAG_COMMIT"
+printf '%s\trefs/tags/v${expectedVersion}\n' "$MOCK_TAG_COMMIT"
 `);
 
     await writeExecutable(join(mockBin, 'npm'), `#!/usr/bin/env bash
@@ -116,7 +117,7 @@ for binary in geoptimize geo geo-cli; do
   if [ "$binary" = "$MOCK_MISSING_BINARY" ]; then
     continue
   fi
-  printf '#!/usr/bin/env bash\nprintf "0.9.0\\n"\n' > "$prefix/node_modules/.bin/$binary"
+  printf '#!/usr/bin/env bash\nprintf "${expectedVersion}\\n"\n' > "$prefix/node_modules/.bin/$binary"
   chmod +x "$prefix/node_modules/.bin/$binary"
 done
 `);
@@ -135,8 +136,8 @@ done
     expect(result.stdout).toContain('PASS: npm gitHead matches');
     expect(result.stdout).toContain('PASS: npm tarball SHA-256 matches the verified candidate');
     expect(result.stdout).toContain('All public release checks passed.');
-    expect(npmArgs).toMatch(/geoptimize-0\.9\.0\.tgz/);
-    expect(npmArgs).not.toContain('geoptimize@0.9.0');
+    expect(npmArgs).toContain(`geoptimize-${expectedVersion}.tgz`);
+    expect(npmArgs).not.toContain(`geoptimize@${expectedVersion}`);
   });
 
   it('fails closed when npm serves a different tarball', async () => {
@@ -177,7 +178,7 @@ done
     });
 
     expect(result.code).toBe(1);
-    expect(result.stderr).toContain('FAIL: v0.9.0 points to');
+    expect(result.stderr).toContain(`FAIL: v${expectedVersion} points to`);
   });
 
   it('fails closed when the GitHub Release is a draft', async () => {

--- a/src/core/__tests__/seo-watch.test.ts
+++ b/src/core/__tests__/seo-watch.test.ts
@@ -1,0 +1,144 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  addSeoWatchword,
+  initializeSeoWatch,
+  loadSeoWatch,
+  recordSeoRank,
+  reviewSeoExperiment,
+  selectSeoCandidate,
+  startSeoExperiment,
+} from '../seo-watch.js';
+
+const temporaryDirectories: string[] = [];
+
+async function repository(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'geoptimize-seo-watch-'));
+  temporaryDirectories.push(directory);
+  await initializeSeoWatch(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe('SEO watch state', () => {
+  it('creates the three versioned data files without overwriting them', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'geoptimize-seo-watch-'));
+    temporaryDirectories.push(directory);
+    await initializeSeoWatch(directory);
+
+    const watchwords = JSON.parse(await readFile(join(directory, 'data/seo/watchwords.json'), 'utf8'));
+    const history = JSON.parse(await readFile(join(directory, 'data/seo/rank-history.json'), 'utf8'));
+    const log = JSON.parse(await readFile(join(directory, 'data/seo/improvement-log.json'), 'utf8'));
+    expect(watchwords).toEqual({ contractVersion: '1.0', watchwords: [] });
+    expect(history).toEqual({ contractVersion: '1.0', observations: [] });
+    expect(log).toEqual({ contractVersion: '1.0', improvements: [] });
+
+    await writeFile(join(directory, 'data/seo/watchwords.json'), '{"owner":"keep"}\n');
+    await expect(initializeSeoWatch(directory)).rejects.toThrow('existing files were preserved');
+    expect(await readFile(join(directory, 'data/seo/watchwords.json'), 'utf8')).toBe('{"owner":"keep"}\n');
+  });
+
+  it('records immutable segmented observations and rejects duplicates', async () => {
+    const directory = await repository();
+    await addSeoWatchword(directory, { keyword: '能源管理系統整合', targetPath: '/platform/', priority: 'high' });
+    const input = {
+      keyword: '能源管理系統整合', targetPath: '/platform/', source: 'gsc' as const,
+      position: 7.2, clicks: 2, impressions: 41,
+      startDate: '2026-08-01', endDate: '2026-08-28', country: 'TWN', device: 'DESKTOP',
+      observedAt: '2026-08-29T02:00:00Z',
+    };
+    const observation = await recordSeoRank(directory, input);
+    await expect(recordSeoRank(directory, input)).rejects.toThrow('history was not changed');
+    const state = await loadSeoWatch(directory);
+    expect(state.rankHistory.observations).toEqual([observation]);
+    expect(observation.segment).toEqual({ country: 'TWN', device: 'DESKTOP', searchType: 'web' });
+  });
+
+  it('maps one exact query to only one target page', async () => {
+    const directory = await repository();
+    await addSeoWatchword(directory, { keyword: 'Energy Management', targetPath: '/one', priority: 'high' });
+    await expect(addSeoWatchword(directory, {
+      keyword: '  energy   management ', targetPath: '/two', priority: 'high',
+    })).rejects.toThrow('one exact query must map to one target page');
+  });
+
+  it('selects one candidate using position, impressions, and stable priorities', async () => {
+    const directory = await repository();
+    await addSeoWatchword(directory, { keyword: 'keyword near page one', targetPath: '/one', priority: 'medium' });
+    await addSeoWatchword(directory, { keyword: 'keyword with demand', targetPath: '/two', priority: 'high' });
+    await addSeoWatchword(directory, { keyword: 'unknown high', targetPath: '/three', priority: 'high' });
+    await recordSeoRank(directory, {
+      keyword: 'keyword near page one', targetPath: '/one', source: 'gsc', position: 8, impressions: 4, clicks: 0,
+      startDate: '2026-08-01', endDate: '2026-08-28', country: 'TWN', device: 'DESKTOP', observedAt: '2026-08-29T00:00:00Z',
+    });
+    await recordSeoRank(directory, {
+      keyword: 'keyword with demand', targetPath: '/two', source: 'gsc', position: 12, impressions: 500, clicks: 2,
+      startDate: '2026-08-01', endDate: '2026-08-28', country: 'TWN', device: 'DESKTOP', observedAt: '2026-08-29T00:00:00Z',
+    });
+    const selected = selectSeoCandidate(await loadSeoWatch(directory));
+    expect(selected?.watchword.keyword).toBe('keyword near page one');
+    expect(selected?.reason).toContain('2–10');
+  });
+
+  it('enforces one active experiment and a seven-day cooldown', async () => {
+    const directory = await repository();
+    await addSeoWatchword(directory, { keyword: 'first', targetPath: '/first', priority: 'high' });
+    await addSeoWatchword(directory, { keyword: 'second', targetPath: '/second', priority: 'medium' });
+    const first = await startSeoExperiment(directory, {
+      keyword: 'first', date: '2026-09-10', searchIntent: 'Compare implementation options',
+      gap: 'The page lacks a concrete scope.', change: 'Added an implementation scope and internal links.',
+    });
+    expect(first.status).toBe('observing');
+    expect(first.nextReviewDate).toBe('2026-09-17');
+    await expect(startSeoExperiment(directory, {
+      keyword: 'second', date: '2026-09-10', searchIntent: 'Find a supplier', gap: 'Missing detail', change: 'Added detail',
+    })).rejects.toThrow('observing until 2026-09-17');
+  });
+
+  it('requires a matching post-action observation before review', async () => {
+    const directory = await repository();
+    await addSeoWatchword(directory, { keyword: 'first', targetPath: '/first', priority: 'high' });
+    await startSeoExperiment(directory, {
+      keyword: 'first', date: '2026-09-10', searchIntent: 'Understand the service',
+      gap: 'Missing inputs and outputs.', change: 'Added visible inputs and outputs.',
+    });
+    const observation = await recordSeoRank(directory, {
+      keyword: 'first', targetPath: '/first', source: 'gsc', position: 4.3, impressions: 20, clicks: 1,
+      startDate: '2026-09-11', endDate: '2026-09-17', country: 'TWN', device: 'DESKTOP', observedAt: '2026-09-18T00:00:00Z',
+    });
+    await expect(reviewSeoExperiment(directory, {
+      keyword: 'first', outcome: 'improved', observationId: observation.id, date: '2026-09-16',
+    })).rejects.toThrow('cooldown until 2026-09-17');
+    const reviewed = await reviewSeoExperiment(directory, {
+      keyword: 'first', outcome: 'improved', observationId: observation.id, date: '2026-09-17', note: 'Position improved.',
+    });
+    expect(reviewed.status).toBe('active');
+    expect(reviewed.nextReviewDate).toBeNull();
+    expect(reviewed.reviews).toHaveLength(1);
+  });
+
+  it('rejects a review that changes the measured segment', async () => {
+    const directory = await repository();
+    await addSeoWatchword(directory, { keyword: 'first', targetPath: '/first', priority: 'high' });
+    await recordSeoRank(directory, {
+      keyword: 'first', targetPath: '/first', source: 'gsc', position: 6, impressions: 20, clicks: 1,
+      startDate: '2026-08-13', endDate: '2026-09-09', country: 'TWN', device: 'DESKTOP', observedAt: '2026-09-10T00:00:00Z',
+    });
+    await startSeoExperiment(directory, {
+      keyword: 'first', date: '2026-09-10', searchIntent: 'Understand the service',
+      gap: 'Missing inputs and outputs.', change: 'Added visible inputs and outputs.',
+    });
+    const mobile = await recordSeoRank(directory, {
+      keyword: 'first', targetPath: '/first', source: 'gsc', position: 4, impressions: 30, clicks: 2,
+      startDate: '2026-09-11', endDate: '2026-09-17', country: 'TWN', device: 'MOBILE', observedAt: '2026-09-18T00:00:00Z',
+    });
+    await expect(reviewSeoExperiment(directory, {
+      keyword: 'first', outcome: 'improved', observationId: mobile.id, date: '2026-09-17',
+    })).rejects.toThrow('same source, country, device, and search type');
+  });
+});

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,3 +11,4 @@ export * from './static-audit.js';
 export * from './site-metrics.js';
 export * from './visual-report.js';
 export * from './readiness-comparison.js';
+export * from './seo-watch.js';

--- a/src/core/seo-watch.ts
+++ b/src/core/seo-watch.ts
@@ -1,0 +1,500 @@
+import { createHash } from 'node:crypto';
+import { access, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+
+export const SEO_WATCH_CONTRACT_VERSION = '1.0' as const;
+export const SEO_WATCH_DIRECTORY = join('data', 'seo');
+export const SEO_WATCH_FILES = {
+  watchwords: 'watchwords.json',
+  rankHistory: 'rank-history.json',
+  improvementLog: 'improvement-log.json',
+} as const;
+
+export type SeoPriority = 'high' | 'medium' | 'low';
+export type SeoWatchStatus = 'active' | 'observing' | 'achieved';
+export type SeoRankSource = 'gsc' | 'serp';
+export type SeoReviewOutcome = 'achieved' | 'improved' | 'unchanged' | 'declined';
+
+export interface SeoWatchword {
+  keyword: string;
+  targetPath: string;
+  priority: SeoPriority;
+  status: SeoWatchStatus;
+  nextReviewDate: string | null;
+}
+
+export interface SeoWatchwordsFile {
+  contractVersion: typeof SEO_WATCH_CONTRACT_VERSION;
+  watchwords: SeoWatchword[];
+}
+
+export interface SeoRankObservation {
+  id: string;
+  observedAt: string;
+  source: SeoRankSource;
+  keyword: string;
+  targetPath: string;
+  position: number | null;
+  clicks: number | null;
+  impressions: number | null;
+  window: {
+    startDate: string;
+    endDate: string;
+  };
+  segment: {
+    country: string;
+    device: string;
+    searchType: string;
+  };
+}
+
+export interface SeoRankHistoryFile {
+  contractVersion: typeof SEO_WATCH_CONTRACT_VERSION;
+  observations: SeoRankObservation[];
+}
+
+export interface SeoImprovementAction {
+  date: string;
+  baselineObservationId: string | null;
+  searchIntent: string;
+  gap: string;
+  change: string;
+}
+
+export interface SeoImprovementReview {
+  date: string;
+  outcome: SeoReviewOutcome;
+  observationId: string;
+  note: string;
+}
+
+export interface SeoImprovement {
+  keyword: string;
+  targetPath: string;
+  status: SeoWatchStatus;
+  nextReviewDate: string | null;
+  actions: SeoImprovementAction[];
+  reviews: SeoImprovementReview[];
+}
+
+export interface SeoImprovementLogFile {
+  contractVersion: typeof SEO_WATCH_CONTRACT_VERSION;
+  improvements: SeoImprovement[];
+}
+
+export interface SeoWatchState {
+  watchwords: SeoWatchwordsFile;
+  rankHistory: SeoRankHistoryFile;
+  improvementLog: SeoImprovementLogFile;
+}
+
+export interface SeoCandidate {
+  watchword: SeoWatchword;
+  latestObservation: SeoRankObservation | null;
+  reason: string;
+}
+
+export interface RecordSeoRankInput {
+  keyword: string;
+  targetPath: string;
+  source: SeoRankSource;
+  position?: number | null;
+  clicks?: number | null;
+  impressions?: number | null;
+  startDate: string;
+  endDate: string;
+  country: string;
+  device: string;
+  searchType?: string;
+  observedAt?: string;
+}
+
+export interface StartSeoExperimentInput {
+  keyword: string;
+  searchIntent: string;
+  gap: string;
+  change: string;
+  date?: string;
+}
+
+export interface ReviewSeoExperimentInput {
+  keyword: string;
+  outcome: SeoReviewOutcome;
+  observationId: string;
+  note?: string;
+  date?: string;
+}
+
+const priorityWeight: Record<SeoPriority, number> = { high: 0, medium: 1, low: 2 };
+
+function text(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} must not be empty.`);
+  return normalized;
+}
+
+function dateOnly(value: string, label: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || Number.isNaN(Date.parse(`${value}T00:00:00Z`))) {
+    throw new Error(`${label} must use YYYY-MM-DD.`);
+  }
+  return value;
+}
+
+function timestamp(value: string, label: string): string {
+  if (Number.isNaN(Date.parse(value))) throw new Error(`${label} must be an ISO timestamp.`);
+  return new Date(value).toISOString();
+}
+
+function nullableNonNegative(value: number | null | undefined, label: string): number | null {
+  if (value === undefined || value === null) return null;
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${label} must be a non-negative number.`);
+  return value;
+}
+
+function normalizeKeyword(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+function sameWatchword(left: Pick<SeoWatchword, 'keyword' | 'targetPath'>, right: Pick<SeoWatchword, 'keyword' | 'targetPath'>): boolean {
+  return normalizeKeyword(left.keyword) === normalizeKeyword(right.keyword) && left.targetPath === right.targetPath;
+}
+
+function sameSegment(left: SeoRankObservation, right: SeoRankObservation): boolean {
+  return left.source === right.source
+    && left.segment.country === right.segment.country
+    && left.segment.device === right.segment.device
+    && left.segment.searchType === right.segment.searchType;
+}
+
+function dayAfter(value: string, days: number): string {
+  const date = new Date(`${dateOnly(value, 'date')}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function emptyState(): SeoWatchState {
+  return {
+    watchwords: { contractVersion: SEO_WATCH_CONTRACT_VERSION, watchwords: [] },
+    rankHistory: { contractVersion: SEO_WATCH_CONTRACT_VERSION, observations: [] },
+    improvementLog: { contractVersion: SEO_WATCH_CONTRACT_VERSION, improvements: [] },
+  };
+}
+
+function paths(repository: string) {
+  const directory = join(repository, SEO_WATCH_DIRECTORY);
+  return {
+    directory,
+    watchwords: join(directory, SEO_WATCH_FILES.watchwords),
+    rankHistory: join(directory, SEO_WATCH_FILES.rankHistory),
+    improvementLog: join(directory, SEO_WATCH_FILES.improvementLog),
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertRepository(repository: string): Promise<void> {
+  const info = await stat(repository);
+  if (!info.isDirectory()) throw new Error('Repository path must be a directory.');
+}
+
+async function atomicJson(path: string, value: unknown): Promise<void> {
+  const tempPath = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`);
+  await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+  await rename(tempPath, path);
+}
+
+function assertVersion(value: unknown, label: string): void {
+  if (value !== SEO_WATCH_CONTRACT_VERSION) {
+    throw new Error(`${label} contractVersion must be ${SEO_WATCH_CONTRACT_VERSION}.`);
+  }
+}
+
+function assertState(state: SeoWatchState): void {
+  assertVersion(state.watchwords.contractVersion, SEO_WATCH_FILES.watchwords);
+  assertVersion(state.rankHistory.contractVersion, SEO_WATCH_FILES.rankHistory);
+  assertVersion(state.improvementLog.contractVersion, SEO_WATCH_FILES.improvementLog);
+  if (!Array.isArray(state.watchwords.watchwords)) throw new Error('watchwords must be an array.');
+  if (!Array.isArray(state.rankHistory.observations)) throw new Error('observations must be an array.');
+  if (!Array.isArray(state.improvementLog.improvements)) throw new Error('improvements must be an array.');
+}
+
+export async function initializeSeoWatch(repository: string): Promise<SeoWatchState> {
+  await assertRepository(repository);
+  const target = paths(repository);
+  const existing = await Promise.all([
+    exists(target.watchwords),
+    exists(target.rankHistory),
+    exists(target.improvementLog),
+  ]);
+  if (existing.some(Boolean)) {
+    throw new Error(`SEO watch data already exists in ${target.directory}; existing files were preserved.`);
+  }
+
+  await mkdir(target.directory, { recursive: true });
+  const state = emptyState();
+  await writeFile(target.watchwords, `${JSON.stringify(state.watchwords, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+  await writeFile(target.rankHistory, `${JSON.stringify(state.rankHistory, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+  await writeFile(target.improvementLog, `${JSON.stringify(state.improvementLog, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+  return state;
+}
+
+export async function loadSeoWatch(repository: string): Promise<SeoWatchState> {
+  await assertRepository(repository);
+  const target = paths(repository);
+  const [watchwords, rankHistory, improvementLog] = await Promise.all([
+    readFile(target.watchwords, 'utf8').then(JSON.parse) as Promise<SeoWatchwordsFile>,
+    readFile(target.rankHistory, 'utf8').then(JSON.parse) as Promise<SeoRankHistoryFile>,
+    readFile(target.improvementLog, 'utf8').then(JSON.parse) as Promise<SeoImprovementLogFile>,
+  ]);
+  const state = { watchwords, rankHistory, improvementLog };
+  assertState(state);
+  return state;
+}
+
+async function saveSeoWatch(repository: string, state: SeoWatchState): Promise<void> {
+  assertState(state);
+  const target = paths(repository);
+  await atomicJson(target.watchwords, state.watchwords);
+  await atomicJson(target.rankHistory, state.rankHistory);
+  await atomicJson(target.improvementLog, state.improvementLog);
+}
+
+export async function addSeoWatchword(
+  repository: string,
+  input: { keyword: string; targetPath: string; priority?: SeoPriority },
+): Promise<SeoWatchword> {
+  const state = await loadSeoWatch(repository);
+  const watchword: SeoWatchword = {
+    keyword: text(input.keyword, 'keyword'),
+    targetPath: text(input.targetPath, 'targetPath'),
+    priority: input.priority ?? 'medium',
+    status: 'active',
+    nextReviewDate: null,
+  };
+  if (!['high', 'medium', 'low'].includes(watchword.priority)) throw new Error('priority must be high, medium, or low.');
+  if (state.watchwords.watchwords.some((item) => normalizeKeyword(item.keyword) === normalizeKeyword(watchword.keyword))) {
+    throw new Error(`Watchword already exists for ${watchword.keyword}; one exact query must map to one target page.`);
+  }
+  state.watchwords.watchwords.push(watchword);
+  state.improvementLog.improvements.push({
+    keyword: watchword.keyword,
+    targetPath: watchword.targetPath,
+    status: 'active',
+    nextReviewDate: null,
+    actions: [],
+    reviews: [],
+  });
+  await saveSeoWatch(repository, state);
+  return watchword;
+}
+
+export async function recordSeoRank(repository: string, input: RecordSeoRankInput): Promise<SeoRankObservation> {
+  const state = await loadSeoWatch(repository);
+  const keyword = text(input.keyword, 'keyword');
+  const targetPath = text(input.targetPath, 'targetPath');
+  const watchword = state.watchwords.watchwords.find((item) => sameWatchword(item, { keyword, targetPath }));
+  if (!watchword) throw new Error(`Add the watchword before recording ${keyword} at ${targetPath}.`);
+  if (!['gsc', 'serp'].includes(input.source)) throw new Error('source must be gsc or serp.');
+
+  const startDate = dateOnly(input.startDate, 'startDate');
+  const endDate = dateOnly(input.endDate, 'endDate');
+  if (startDate > endDate) throw new Error('startDate must not be after endDate.');
+  const observedAt = timestamp(input.observedAt ?? new Date().toISOString(), 'observedAt');
+  const position = nullableNonNegative(input.position, 'position');
+  const clicks = nullableNonNegative(input.clicks, 'clicks');
+  const impressions = nullableNonNegative(input.impressions, 'impressions');
+  if (clicks !== null && impressions !== null && clicks > impressions) {
+    throw new Error('clicks must not exceed impressions.');
+  }
+
+  const country = text(input.country, 'country');
+  const device = text(input.device, 'device');
+  const searchType = text(input.searchType ?? 'web', 'searchType');
+  const identity = JSON.stringify({
+    observedAt, source: input.source, keyword, targetPath, position, clicks, impressions,
+    startDate, endDate, country, device, searchType,
+  });
+  const observation: SeoRankObservation = {
+    id: createHash('sha256').update(identity).digest('hex').slice(0, 16),
+    observedAt,
+    source: input.source,
+    keyword,
+    targetPath,
+    position,
+    clicks,
+    impressions,
+    window: { startDate, endDate },
+    segment: {
+      country,
+      device,
+      searchType,
+    },
+  };
+  if (state.rankHistory.observations.some((item) => item.id === observation.id)) {
+    throw new Error(`Rank observation ${observation.id} already exists; history was not changed.`);
+  }
+  state.rankHistory.observations.push(observation);
+  await saveSeoWatch(repository, state);
+  return observation;
+}
+
+function latestObservation(state: SeoWatchState, watchword: SeoWatchword): SeoRankObservation | null {
+  return state.rankHistory.observations
+    .filter((item) => sameWatchword(watchword, item))
+    .sort((left, right) => right.observedAt.localeCompare(left.observedAt))[0] ?? null;
+}
+
+function lastReviewOutcome(state: SeoWatchState, watchword: SeoWatchword): SeoReviewOutcome | null {
+  const improvement = state.improvementLog.improvements.find((item) => sameWatchword(item, watchword));
+  return improvement?.reviews.at(-1)?.outcome ?? null;
+}
+
+export function selectSeoCandidate(state: SeoWatchState): SeoCandidate | null {
+  assertState(state);
+  if (state.watchwords.watchwords.some((item) => item.status === 'observing')) return null;
+  const candidates = state.watchwords.watchwords
+    .filter((item) => item.status === 'active')
+    .map((watchword, index) => ({
+      watchword,
+      index,
+      observation: latestObservation(state, watchword),
+      reviewOutcome: lastReviewOutcome(state, watchword),
+    }));
+  if (candidates.length === 0) return null;
+
+  const ranked = candidates.map((candidate) => {
+    const position = candidate.observation?.position;
+    const impressions = candidate.observation?.impressions ?? 0;
+    if (position !== null && position !== undefined && position >= 2 && position <= 10 && impressions > 0) {
+      return { ...candidate, group: 0, reason: 'Observed in positions 2–10 with impressions; closest position wins.' };
+    }
+    if (position !== null && position !== undefined && position > 10 && position <= 20 && impressions > 0) {
+      return { ...candidate, group: 1, reason: 'Observed in positions 11–20 with impressions; higher demand wins.' };
+    }
+    if (candidate.reviewOutcome && candidate.reviewOutcome !== 'achieved') {
+      return { ...candidate, group: 2, reason: 'A reviewed experiment remains short of the goal; use a different change.' };
+    }
+    if ((position === null || position === undefined) && candidate.watchword.priority === 'high') {
+      return { ...candidate, group: 3, reason: 'High-priority watchword has no observed position.' };
+    }
+    return { ...candidate, group: 4, reason: 'Active watchword selected by priority and stable file order.' };
+  });
+
+  ranked.sort((left, right) => {
+    if (left.group !== right.group) return left.group - right.group;
+    if (left.group === 0) return (left.observation?.position ?? Infinity) - (right.observation?.position ?? Infinity);
+    if (left.group === 1) {
+      const impressionDelta = (right.observation?.impressions ?? 0) - (left.observation?.impressions ?? 0);
+      if (impressionDelta !== 0) return impressionDelta;
+      return (left.observation?.position ?? Infinity) - (right.observation?.position ?? Infinity);
+    }
+    const priorityDelta = priorityWeight[left.watchword.priority] - priorityWeight[right.watchword.priority];
+    return priorityDelta || left.index - right.index;
+  });
+  const selected = ranked[0];
+  return { watchword: selected.watchword, latestObservation: selected.observation, reason: selected.reason };
+}
+
+export async function startSeoExperiment(repository: string, input: StartSeoExperimentInput): Promise<SeoImprovement> {
+  const state = await loadSeoWatch(repository);
+  const selected = selectSeoCandidate(state);
+  if (!selected) {
+    const observing = state.watchwords.watchwords.find((item) => item.status === 'observing');
+    if (observing) throw new Error(`${observing.keyword} is observing until ${observing.nextReviewDate}; do not start another experiment.`);
+    throw new Error('No active SEO watchword is available.');
+  }
+  if (normalizeKeyword(selected.watchword.keyword) !== normalizeKeyword(input.keyword)) {
+    throw new Error(`Selected watchword is ${selected.watchword.keyword}; start that experiment or update the watchword priorities.`);
+  }
+
+  const date = dateOnly(input.date ?? todayUtc(), 'date');
+  const nextReviewDate = dayAfter(date, 7);
+  const watchword = state.watchwords.watchwords.find((item) => sameWatchword(item, selected.watchword))!;
+  const improvement = state.improvementLog.improvements.find((item) => sameWatchword(item, selected.watchword))!;
+  watchword.status = 'observing';
+  watchword.nextReviewDate = nextReviewDate;
+  improvement.status = 'observing';
+  improvement.nextReviewDate = nextReviewDate;
+  improvement.actions.push({
+    date,
+    baselineObservationId: selected.latestObservation?.id ?? null,
+    searchIntent: text(input.searchIntent, 'searchIntent'),
+    gap: text(input.gap, 'gap'),
+    change: text(input.change, 'change'),
+  });
+  await saveSeoWatch(repository, state);
+  return improvement;
+}
+
+export async function reviewSeoExperiment(repository: string, input: ReviewSeoExperimentInput): Promise<SeoImprovement> {
+  const state = await loadSeoWatch(repository);
+  const watchword = state.watchwords.watchwords.find((item) => normalizeKeyword(item.keyword) === normalizeKeyword(input.keyword));
+  if (!watchword) throw new Error(`Unknown watchword: ${input.keyword}.`);
+  if (watchword.status !== 'observing' || !watchword.nextReviewDate) {
+    throw new Error(`${watchword.keyword} is not currently observing.`);
+  }
+  const date = dateOnly(input.date ?? todayUtc(), 'date');
+  if (date < watchword.nextReviewDate) {
+    throw new Error(`${watchword.keyword} remains in cooldown until ${watchword.nextReviewDate}.`);
+  }
+  if (!['achieved', 'improved', 'unchanged', 'declined'].includes(input.outcome)) {
+    throw new Error('outcome must be achieved, improved, unchanged, or declined.');
+  }
+  const observation = state.rankHistory.observations.find((item) => item.id === input.observationId);
+  if (!observation || !sameWatchword(watchword, observation)) {
+    throw new Error('Review observation must exist and match the watchword and target path.');
+  }
+  const action = state.improvementLog.improvements.find((item) => sameWatchword(item, watchword))?.actions.at(-1);
+  if (!action || observation.window.endDate <= action.date) {
+    throw new Error('Review observation must cover a period ending after the latest action date.');
+  }
+  if (action.baselineObservationId) {
+    const baseline = state.rankHistory.observations.find((item) => item.id === action.baselineObservationId);
+    if (!baseline) throw new Error('The latest action references a missing baseline observation.');
+    if (!sameSegment(baseline, observation)) {
+      throw new Error('Review observation must use the same source, country, device, and search type as the baseline.');
+    }
+  }
+
+  const status: SeoWatchStatus = input.outcome === 'achieved' ? 'achieved' : 'active';
+  watchword.status = status;
+  watchword.nextReviewDate = null;
+  const improvement = state.improvementLog.improvements.find((item) => sameWatchword(item, watchword))!;
+  improvement.status = status;
+  improvement.nextReviewDate = null;
+  improvement.reviews.push({
+    date,
+    outcome: input.outcome,
+    observationId: observation.id,
+    note: input.note?.trim() ?? '',
+  });
+  await saveSeoWatch(repository, state);
+  return improvement;
+}
+
+export function summarizeSeoWatch(state: SeoWatchState) {
+  assertState(state);
+  const candidate = selectSeoCandidate(state);
+  return {
+    contractVersion: SEO_WATCH_CONTRACT_VERSION,
+    counts: {
+      active: state.watchwords.watchwords.filter((item) => item.status === 'active').length,
+      observing: state.watchwords.watchwords.filter((item) => item.status === 'observing').length,
+      achieved: state.watchwords.watchwords.filter((item) => item.status === 'achieved').length,
+      observations: state.rankHistory.observations.length,
+    },
+    candidate,
+    observing: state.watchwords.watchwords.filter((item) => item.status === 'observing'),
+  };
+}


### PR DESCRIPTION
## Summary

- Add a separate SEO rank-watch ledger and CLI workflow with fixed comparison segments, one observing experiment, and a seven-day post-publication cooldown.
- Prepare the compatible 0.10.0 package, Action, plugin, and release metadata without changing readiness scoring or audit contracts.

## Test plan

- npm run release:check

## For reviewers

Confirm that the cooldown can start only after the changed page is publicly deployed.