### PR TITLE
docs: add multilingual README guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable user-visible changes will be documented here. The project follows Se
 - Added `geo seo` commands for versioned query, observation, and experiment ledgers.
 - Added fixed query-segment evidence, one-experiment-at-a-time selection, and a seven-day post-publication review cooldown.
 - Added a reusable SEO experiment-ledger skill and workflow documentation.
+- Added concise README guides in Traditional Chinese, Simplified Chinese, Japanese, Korean, Spanish, French, German, and Brazilian Portuguese.
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # geoptimize
 
+[English](README.md) | [繁體中文](docs/readme/README.zh-TW.md) | [简体中文](docs/readme/README.zh-CN.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português do Brasil](docs/readme/README.pt-BR.md)
+
 **Formerly aeoptimize.** This is the same project, continued under the `geoptimize` name from version 0.8.0. Existing `aeoptimize` users can follow the [migration guide](https://github.com/cucuwang/geoptimize/blob/main/docs/migrating-from-aeoptimize.md).
 
 [Current npm package](https://www.npmjs.com/package/geoptimize) · [Legacy npm package and download history](https://www.npmjs.com/package/aeoptimize) · [Last release under the old name](https://github.com/cucuwang/geoptimize/releases/tag/v0.7.0)

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**Früher aeoptimize.** Seit Version `0.8.0` wird dasselbe Projekt unter dem Namen `geoptimize` weitergeführt. Bestehende Benutzer finden die nötigen Schritte im [Migrationsleitfaden](../migrating-from-aeoptimize.md).
+
+`geoptimize` ist ein deterministischer Content-Readiness-Linter für statische Websites und technische Dokumentation. Er prüft Dokumentstruktur, Quellenhinweise für quantitative Aussagen, strukturierte Daten, Indexierungssteuerung, Qualität der metadata und wiederholte Formulierungen. Er läuft lokal, in CI oder als pre-commit-Prüfung.
+
+## Installation und Schnellstart
+
+Erforderlich ist Node.js 22.12 oder neuer.
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` erzeugt einen versionierten Content-Readiness-Wert. Er eignet sich zum Erkennen von Regressionen innerhalb desselben Projekts. Er ist keine Wahrscheinlichkeit für Ranking, Indexierung, rich results oder Zitate durch KI-Systeme.
+
+## Nachweisgestützte Website-Audits
+
+`audit` prüft eine öffentliche URL oder eine lokale HTML- oder Markdown-Datei. `audit-site` prüft Links desselben Ursprungs, robots, sitemap, canonical, Weiterleitungen und doppelte Titel innerhalb eines ausdrücklich gesetzten Seitenlimits. `audit-build` kontrolliert das erzeugte HTML vor dem Deployment.
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+Jede Prüfung enthält die beobachteten Nachweise und einen Status `PASS`, `WARNING`, `FAIL` oder `N/A`. Der Umfang bleibt auf die tatsächlich gelesenen Dateien, URLs und Seiten begrenzt.
+
+## SEO Experiment Ledger
+
+Das SEO-Experimentprotokoll arbeitet unabhängig vom Content-Readiness-Wert. Es speichert Suchanfragen, Messbedingungen, Seitenänderungen und Reviews. Pro repository kann jeweils nur ein Experiment überwacht werden.
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+Die Daten liegen in `data/seo/queries.json`, `observations.json` und `experiments.json`. Stellen Sie die Seite bereit und lesen Sie den öffentlichen Inhalt zurück, bevor Sie den Beobachtungszeitraum starten. Der vollständige Ablauf steht unter [SEO experiment ledger](../seo-experiment-ledger.md).
+
+## CI und GitHub Action
+
+Die GitHub Action liefert standardmäßig Hinweise. Nachdem ein Team den Ausgangswert akzeptiert hat, kann es einen Mindestwert zum Blockieren von Regressionen setzen.
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON ist die stabile Automatisierungsschnittstelle. Regeln, Nachweisklassen und bekannte Grenzen sind in der [Methodik](../methodology.md) dokumentiert.
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+Das Paket enthält `/geo-scan`, `/geo-generate`, `/geo-transform` und `/seo-experiment-ledger`.
+
+## Lizenz und vollständige Dokumentation
+
+Das Projekt steht unter der MIT License. Die englische [README](../../README.md) enthält alle Befehle, Berichte, Plugins, Action contracts, methodischen Grenzen und Angaben zur release integrity.

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**Antes se llamaba aeoptimize.** Desde la versión `0.8.0`, el mismo proyecto continúa como `geoptimize`. Los usuarios existentes pueden consultar la [guía de migración](../migrating-from-aeoptimize.md).
+
+`geoptimize` es un linter determinista de preparación de contenido para sitios estáticos y documentación técnica. Comprueba la estructura del documento, las señales de fuentes para afirmaciones cuantitativas, los datos estructurados, los controles de indexación, la calidad de los metadata y el texto repetitivo. Se ejecuta en local, CI o pre-commit.
+
+## Instalación e inicio rápido
+
+Requiere Node.js 22.12 o una versión posterior.
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` produce una puntuación versionada de preparación del contenido. Sirve para detectar regresiones dentro del mismo proyecto. No representa la probabilidad de posicionamiento, indexación, rich results ni citas de sistemas de IA.
+
+## Auditorías con evidencia
+
+`audit` inspecciona una URL pública o un archivo HTML o Markdown local. `audit-site` comprueba enlaces del mismo origen, robots, sitemap, canonical, redirecciones y títulos duplicados dentro de un límite explícito de páginas. `audit-build` revisa el HTML generado antes del despliegue.
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+Cada comprobación incluye la evidencia observada y un estado `PASS`, `WARNING`, `FAIL` o `N/A`. El alcance queda limitado a los archivos, las URL y las páginas que se hayan leído.
+
+## SEO Experiment Ledger
+
+El registro de experimentos SEO funciona de forma independiente de la puntuación de preparación. Conserva las consultas, las condiciones de medición, los cambios de página y las revisiones. Solo permite un experimento en seguimiento a la vez por repository.
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+Los datos se guardan en `data/seo/queries.json`, `observations.json` y `experiments.json`. Despliega la página y comprueba el contenido público antes de iniciar el periodo de seguimiento. Consulta [SEO experiment ledger](../seo-experiment-ledger.md) para ver el flujo completo.
+
+## CI y GitHub Action
+
+La GitHub Action es informativa de forma predeterminada. Después de aceptar una línea base, el equipo puede configurar una puntuación mínima para bloquear regresiones.
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON es la interfaz estable para automatización. Las reglas, las clases de evidencia y las limitaciones conocidas se describen en la [metodología](../methodology.md).
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+El paquete incluye `/geo-scan`, `/geo-generate`, `/geo-transform` y `/seo-experiment-ledger`.
+
+## Licencia y documentación completa
+
+El proyecto usa la licencia MIT. El [README en inglés](../../README.md) contiene todos los comandos, informes, plugins, Action contracts, límites metodológicos y detalles de release integrity.

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**Anciennement aeoptimize.** Depuis la version `0.8.0`, le même projet continue sous le nom `geoptimize`. Les utilisateurs existants peuvent consulter le [guide de migration](../migrating-from-aeoptimize.md).
+
+`geoptimize` est un linter déterministe de préparation du contenu pour les sites statiques et la documentation technique. Il vérifie la structure du document, les signaux de source des affirmations chiffrées, les données structurées, les contrôles d'indexation, la qualité des metadata et les formulations répétitives. Il fonctionne en local, en CI ou en pre-commit.
+
+## Installation et démarrage rapide
+
+Node.js 22.12 ou une version ultérieure est requis.
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` produit un score versionné de préparation du contenu. Ce score sert à détecter les régressions au sein d'un même projet. Il ne représente pas une probabilité de classement, d'indexation, de rich result ou de citation par un système d'IA.
+
+## Audits fondés sur des preuves
+
+`audit` inspecte une URL publique ou un fichier HTML ou Markdown local. `audit-site` vérifie les liens de même origine, robots, sitemap, canonical, redirections et titres dupliqués dans une limite explicite de pages. `audit-build` contrôle le HTML généré avant le déploiement.
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+Chaque contrôle inclut les preuves observées et un état `PASS`, `WARNING`, `FAIL` ou `N/A`. La portée reste limitée aux fichiers, URL et pages effectivement lus.
+
+## SEO Experiment Ledger
+
+Le registre d'expériences SEO fonctionne indépendamment du score de préparation. Il conserve les requêtes, les conditions de mesure, les modifications de page et les revues. Un seul experiment peut être suivi à la fois dans un repository.
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+Les données sont enregistrées dans `data/seo/queries.json`, `observations.json` et `experiments.json`. Déployez la page et relisez son contenu public avant de commencer la période de suivi. Consultez [SEO experiment ledger](../seo-experiment-ledger.md) pour le processus complet.
+
+## CI et GitHub Action
+
+La GitHub Action fournit des résultats consultatifs par défaut. Après validation d'une référence, l'équipe peut définir un score minimal pour bloquer les régressions.
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON est l'interface d'automatisation stable. Les règles, les classes de preuves et les limites connues sont décrites dans la [méthodologie](../methodology.md).
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+Le package fournit `/geo-scan`, `/geo-generate`, `/geo-transform` et `/seo-experiment-ledger`.
+
+## Licence et documentation complète
+
+Le projet est distribué sous licence MIT. Le [README anglais](../../README.md) contient toutes les commandes, les rapports, les plugins, les Action contracts, les limites méthodologiques et les informations de release integrity.

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**旧称 aeoptimize。** バージョン `0.8.0` から `geoptimize` に改名し、同じプロジェクト履歴を継続しています。既存ユーザーは[移行ガイド](../migrating-from-aeoptimize.md)を参照してください。
+
+`geoptimize` は、静的サイトと技術文書向けの決定論的なコンテンツ準備状況リンターです。文書構造、数値主張の出典シグナル、構造化データ、インデックス制御、metadata の品質、重複表現をローカル、CI、pre-commit で検査します。
+
+## インストールとクイックスタート
+
+Node.js 22.12 以降が必要です。
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` はバージョン管理されたコンテンツ準備状況スコアを返します。同じプロジェクト内の回帰検出に使う指標であり、検索順位、インデックス登録、rich result、AI からの引用確率を示すものではありません。
+
+## 証拠を伴うサイト監査
+
+`audit` は公開 URL またはローカルの HTML、Markdown ファイルを 1 件検査します。`audit-site` は明示したページ上限の範囲で、同一オリジンのリンク、robots、sitemap、canonical、リダイレクト、重複タイトルを検査します。`audit-build` はデプロイ前の生成済み HTML を検査します。
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+各結果には観測証拠と `PASS`、`WARNING`、`FAIL`、`N/A` が含まれます。適用範囲は、実際に読み取ったファイル、URL、ページ数に限定されます。
+
+## SEO Experiment Ledger
+
+SEO 実験台帳はコンテンツ準備状況スコアから独立しています。クエリ、測定条件、ページ変更、レビューを保存し、1 つの repository で同時に監視できる実験を 1 件に制限します。
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+台帳は `data/seo/queries.json`、`observations.json`、`experiments.json` に保存されます。監視期間を始める前にページをデプロイし、公開内容を確認してください。詳しくは [SEO experiment ledger](../seo-experiment-ledger.md) を参照してください。
+
+## CI と GitHub Action
+
+GitHub Action は既定で助言のみを行います。チームが基準値を確認した後、最低スコアを設定して回帰をブロックできます。
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON が安定した自動化インターフェースです。ルール、証拠区分、既知の制限は[方法論](../methodology.md)に記載されています。
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+パッケージには `/geo-scan`、`/geo-generate`、`/geo-transform`、`/seo-experiment-ledger` が含まれます。
+
+## ライセンスと完全版ドキュメント
+
+MIT License で提供します。すべてのコマンド、レポート、plugin、Action contract、方法上の制限、release integrity については英語版 [README](../../README.md) を参照してください。

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**이전 이름은 aeoptimize입니다.** 버전 `0.8.0`부터 `geoptimize`라는 이름으로 같은 프로젝트의 개발 이력을 이어갑니다. 기존 사용자는 [마이그레이션 안내](../migrating-from-aeoptimize.md)를 참고하세요.
+
+`geoptimize`는 정적 웹사이트와 기술 문서를 위한 결정론적 콘텐츠 준비 상태 린터입니다. 문서 구조, 수치 주장에 대한 출처 신호, 구조화 데이터, 색인 제어, metadata 품질, 반복 표현을 로컬 환경과 CI, pre-commit 단계에서 검사합니다.
+
+## 설치와 빠른 시작
+
+Node.js 22.12 이상이 필요합니다.
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan`은 버전이 지정된 콘텐츠 준비 상태 점수를 제공합니다. 이 점수는 같은 프로젝트의 회귀를 추적하는 용도이며 검색 순위, 색인 등록, rich result, AI 인용 가능성을 뜻하지 않습니다.
+
+## 증거 기반 사이트 감사
+
+`audit`은 공개 URL 하나 또는 로컬 HTML, Markdown 파일 하나를 검사합니다. `audit-site`는 명시된 페이지 한도 안에서 동일 출처 링크, robots, sitemap, canonical, 리디렉션, 중복 제목을 검사합니다. `audit-build`는 배포 전 빌드된 HTML을 검사합니다.
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+각 결과에는 관찰된 증거와 `PASS`, `WARNING`, `FAIL`, `N/A` 상태가 포함됩니다. 감사 범위는 실제로 읽은 파일, URL, 페이지 수로 제한됩니다.
+
+## SEO Experiment Ledger
+
+SEO 실험 원장은 콘텐츠 준비 상태 점수와 독립적으로 동작합니다. 검색어, 측정 조건, 페이지 변경, 검토 결과를 저장하며 하나의 repository에서 동시에 모니터링하는 실험을 한 건으로 제한합니다.
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+원장 데이터는 `data/seo/queries.json`, `observations.json`, `experiments.json`에 저장됩니다. 모니터링 기간을 시작하기 전에 페이지를 배포하고 공개 결과를 다시 확인하세요. 전체 절차는 [SEO experiment ledger](../seo-experiment-ledger.md)를 참고하세요.
+
+## CI와 GitHub Action
+
+GitHub Action은 기본적으로 권고 결과만 제공합니다. 팀에서 기준값을 승인한 뒤 최소 점수로 회귀를 차단할 수 있습니다.
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON은 안정적인 자동화 인터페이스입니다. 규칙, 증거 분류, 알려진 제한은 [방법론 문서](../methodology.md)에 정리되어 있습니다.
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+패키지에는 `/geo-scan`, `/geo-generate`, `/geo-transform`, `/seo-experiment-ledger`가 포함됩니다.
+
+## 라이선스와 전체 문서
+
+MIT License로 배포됩니다. 모든 명령, 보고서, plugin, Action contract, 방법상 제한, release integrity 설명은 영어 [README](../../README.md)에 있습니다.

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**Anteriormente chamado aeoptimize.** A partir da versão `0.8.0`, o mesmo projeto continua com o nome `geoptimize`. Usuários existentes podem consultar o [guia de migração](../migrating-from-aeoptimize.md).
+
+`geoptimize` é um linter determinístico de preparação de conteúdo para sites estáticos e documentação técnica. Ele verifica a estrutura do documento, sinais de fonte para afirmações quantitativas, dados estruturados, controles de indexação, qualidade dos metadata e texto repetitivo. Pode ser executado localmente, na CI ou em pre-commit.
+
+## Instalação e início rápido
+
+Requer Node.js 22.12 ou uma versão mais recente.
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` gera uma pontuação versionada de preparação do conteúdo. Ela serve para detectar regressões no mesmo projeto. Não representa a probabilidade de ranking, indexação, rich results ou citações por sistemas de IA.
+
+## Auditorias baseadas em evidências
+
+`audit` inspeciona uma URL pública ou um arquivo HTML ou Markdown local. `audit-site` verifica links da mesma origem, robots, sitemap, canonical, redirecionamentos e títulos duplicados dentro de um limite explícito de páginas. `audit-build` verifica o HTML gerado antes do deploy.
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+Cada verificação inclui a evidência observada e um estado `PASS`, `WARNING`, `FAIL` ou `N/A`. O escopo permanece limitado aos arquivos, URLs e páginas realmente lidos.
+
+## SEO Experiment Ledger
+
+O registro de experimentos de SEO funciona de forma independente da pontuação de preparação. Ele preserva consultas, condições de medição, mudanças de página e revisões. Apenas um experimento pode ficar em monitoramento por vez em cada repository.
+
+```bash
+geo seo init .
+geo seo add . --keyword "energy management system integration" --page /services/ems/ --priority high
+geo seo status .
+```
+
+Os dados ficam em `data/seo/queries.json`, `observations.json` e `experiments.json`. Faça o deploy da página e releia o conteúdo público antes de iniciar o período de monitoramento. Consulte [SEO experiment ledger](../seo-experiment-ledger.md) para ver o fluxo completo.
+
+## CI e GitHub Action
+
+A GitHub Action fornece resultados consultivos por padrão. Depois que a equipe aceitar uma linha de base, ela pode definir uma pontuação mínima para bloquear regressões.
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON é a interface estável de automação. As regras, classes de evidência e limitações conhecidas estão descritas na [metodologia](../methodology.md).
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+O pacote inclui `/geo-scan`, `/geo-generate`, `/geo-transform` e `/seo-experiment-ledger`.
+
+## Licença e documentação completa
+
+O projeto usa a MIT License. O [README em inglês](../../README.md) contém todos os comandos, relatórios, plugins, Action contracts, limites metodológicos e detalhes de release integrity.

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**原名 aeoptimize。** 项目从 `0.8.0` 起更名为 `geoptimize`，并延续同一份开发历史。现有用户可参考[迁移指南](../migrating-from-aeoptimize.md)。
+
+`geoptimize` 是面向静态网站和技术文档的确定性内容就绪度检查工具。它可以在本地、CI 或 pre-commit 阶段检查文档结构、量化主张的来源信号、结构化数据、索引控制、metadata 质量和重复用语。
+
+## 安装与快速开始
+
+需要 Node.js 22.12 或更新版本。
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` 会生成版本化的内容就绪度分数。该分数适合跟踪同一项目的回归，不能用作搜索排名、收录、rich result 或 AI 引用概率。
+
+## 可验证的网站审计
+
+`audit` 检查单个公开网址或本地 HTML、Markdown 文件。`audit-site` 按明确的页数上限检查同域链接、robots、sitemap、canonical、重定向和重复标题。`audit-build` 在部署前检查构建后的 HTML。
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+每项结果都会返回观测证据以及 `PASS`、`WARNING`、`FAIL` 或 `N/A`。检查范围以实际读取到的文件、网址和页数为准。
+
+## SEO Experiment Ledger
+
+SEO 实验账本与内容就绪度分数分开运行。它保存查询、测量条件、页面修改和后续复盘，并限制同一个 repository 同时只有一项实验进入监测期。
+
+```bash
+geo seo init .
+geo seo add . --keyword "能源管理系统集成" --page /services/ems/ --priority high
+geo seo status .
+```
+
+账本数据位于 `data/seo/queries.json`、`observations.json` 和 `experiments.json`。开始监测前应先部署页面并读回公开内容。完整流程请参阅 [SEO experiment ledger](../seo-experiment-ledger.md)。
+
+## CI 与 GitHub Action
+
+GitHub Action 默认提供建议性检查。团队接受基准后，可以设置最低分数来阻止回归。
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON 是稳定的自动化接口。规则、证据分类和已知限制记录在[方法文档](../methodology.md)中。
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+软件包提供 `/geo-scan`、`/geo-generate`、`/geo-transform` 和 `/seo-experiment-ledger`。
+
+## 许可证与完整文档
+
+项目使用 MIT License。英文 [README](../../README.md) 保留完整命令、报表、plugin、Action contract、方法限制和 release integrity 说明。

--- a/docs/readme/README.zh-TW.md
+++ b/docs/readme/README.zh-TW.md
@@ -1,0 +1,75 @@
+# geoptimize
+
+[English](../../README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português do Brasil](README.pt-BR.md)
+
+**原名 aeoptimize。** 專案自 `0.8.0` 起改名為 `geoptimize` 並延續同一份開發歷史。既有使用者可參考[遷移指南](../migrating-from-aeoptimize.md)。
+
+`geoptimize` 是給靜態網站與技術文件使用的確定性內容就緒度檢查工具。它可以在本機、CI 或 pre-commit 階段檢查文件結構、量化主張的來源訊號、結構化資料、索引控制、metadata 品質與重複用語。
+
+## 安裝與快速開始
+
+需要 Node.js 22.12 或更新版本。
+
+```bash
+npm install --save-dev geoptimize
+```
+
+```bash
+npx geoptimize scan https://example.com
+npx geoptimize scan ./dist --dir --json
+npx geoptimize audit https://example.com --json
+npx geoptimize audit-site https://example.com --max-pages 20 --json
+```
+
+`scan` 產生版本化的內容就緒度分數。這個分數適合用來追蹤同一專案的回歸，不能當成搜尋排名、收錄、rich result 或 AI 引用機率。
+
+## 可驗證的網站稽核
+
+`audit` 檢查單一公開網址或本機 HTML、Markdown 檔案。`audit-site` 依明確頁數上限檢查同網域連結、robots、sitemap、canonical、重新導向與重複標題。`audit-build` 在部署前檢查建置後的 HTML。
+
+```bash
+npx geoptimize audit-build ./dist \
+  --base-url https://example.com/ \
+  --expect-indexable \
+  --fail-on-error \
+  --json
+```
+
+每一項結果都會回報觀察證據與 `PASS`、`WARNING`、`FAIL` 或 `N/A`。檢查範圍以實際讀到的檔案、網址與頁數為準。
+
+## SEO Experiment Ledger
+
+SEO 實驗帳本和內容就緒度分數分開運作。它保存查詢、量測條件、頁面變更與後續檢討，並限制同一個 repository 同時只有一項實驗進入監測期。
+
+```bash
+geo seo init .
+geo seo add . --keyword "能源管理系統整合" --page /services/ems/ --priority high
+geo seo status .
+```
+
+帳本資料位於 `data/seo/queries.json`、`observations.json` 與 `experiments.json`。開始監測前應先部署頁面並讀回公開內容。完整流程請見 [SEO experiment ledger](../seo-experiment-ledger.md)。
+
+## CI 與 GitHub Action
+
+GitHub Action 預設提供建議性檢查。團隊接受基準後，可設定最低分數來阻擋回歸。
+
+```yaml
+- uses: cucuwang/geoptimize@v0.10.0
+  with:
+    path: dist
+```
+
+JSON 是穩定的自動化介面。規則、證據分類與已知限制記錄於[方法文件](../methodology.md)。
+
+## Agent Skills
+
+```bash
+claude plugin marketplace add cucuwang/geoptimize
+npx skills add cucuwang/geoptimize
+```
+
+套件提供 `/geo-scan`、`/geo-generate`、`/geo-transform` 與 `/seo-experiment-ledger`。
+
+## 授權與完整文件
+
+專案採用 MIT License。英文 [README](../../README.md) 保留完整命令、報表、plugin、Action contract、方法限制與 release integrity 說明。

--- a/docs/release-notes-v0.10.md
+++ b/docs/release-notes-v0.10.md
@@ -6,6 +6,7 @@
 - Keeps one page experiment monitoring at a time and starts its seven-day review period only after public deployment.
 - Preserves fixed query, page, country, device, search type, and date-window evidence for later review.
 - Includes the reusable `/seo-experiment-ledger` skill and workflow guide.
+- Includes localized README guides for eight widely used languages.
 
 ## Release integrity
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "docs/release-v0.10.md",
     "docs/visual-report.md",
     "docs/seo-experiment-ledger.md",
+    "docs/readme/",
     "docs/assets/",
     "docs/maintainer-security-settings.md",
     "docs/openssf-best-practices.md",

--- a/scripts/verify-release-candidate.sh
+++ b/scripts/verify-release-candidate.sh
@@ -68,6 +68,14 @@ jq -e '
   (.[0].files | map(.path) | index("docs/release-v0.10.md")) != null and
   (.[0].files | map(.path) | index("docs/seo-experiment-ledger.md")) != null and
   (.[0].files | map(.path) | index("skills/seo-experiment-ledger/SKILL.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.zh-TW.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.zh-CN.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.ja.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.ko.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.es.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.fr.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.de.md")) != null and
+  (.[0].files | map(.path) | index("docs/readme/README.pt-BR.md")) != null and
   (.[0].files | map(.path) | index("docs/assets/report-demo.html")) != null and
   (.[0].files | map(.path) | index("docs/assets/report-demo-after.html")) != null and
   (.[0].files | map(.path) | index("docs/release-v0.8.md")) != null and

--- a/src/core/__tests__/evidence-boundaries.test.ts
+++ b/src/core/__tests__/evidence-boundaries.test.ts
@@ -59,6 +59,32 @@ describe('evidence boundaries', () => {
 });
 
 describe('public metadata', () => {
+  it('links and ships every localized README', async () => {
+    const readme = await readFile(join(root, 'README.md'), 'utf8');
+    const localizedReadmes = [
+      'README.zh-TW.md',
+      'README.zh-CN.md',
+      'README.ja.md',
+      'README.ko.md',
+      'README.es.md',
+      'README.fr.md',
+      'README.de.md',
+      'README.pt-BR.md',
+    ];
+
+    const contents = await Promise.all(localizedReadmes.map(async (filename) => {
+      expect(readme).toContain(`docs/readme/${filename}`);
+      return readFile(join(root, 'docs', 'readme', filename), 'utf8');
+    }));
+
+    for (const content of contents) {
+      expect(content).toContain('# geoptimize');
+      expect(content).toContain('npm install --save-dev geoptimize');
+      expect(content).toContain('geo seo init .');
+      expect(content).toContain('../../README.md');
+    }
+  });
+
   it('uses the current repository owner and exposes root Action metadata', async () => {
     const paths = [
       'README.md',


### PR DESCRIPTION
## Summary

Adds concise getting-started guides for Traditional Chinese, Simplified Chinese, Japanese, Korean, Spanish, French, German, and Brazilian Portuguese. The package and release verifier now include and validate every guide.

## Verification

- `npm test` (251 tests)
- clean release candidate gate
- local package SHA-256: `dbe2d0702020875a1cbef60a52c82cf3415c5f75ee2b44ff88dacb021e023d7c`

## For reviewers

Please verify that the translated commands and links stay aligned with the English README.