### PR TITLE
docs: sync v0.10 release state

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Te-Shu Wang"
   },
   "metadata": {
-    "description": "Content-readiness lint with evidence-bounded AI discovery experiments",
+    "description": "Content-readiness lint with an evidence-bounded SEO experiment ledger",
     "version": "0.10.0"
   },
   "plugins": [
     {
       "name": "geoptimize",
       "source": "./",
-      "description": "CLI and Claude Code skills for reproducible content-readiness checks",
+      "description": "CLI and skills for content-readiness checks and SEO experiments",
       "category": "seo",
       "tags": ["geo", "seo", "ai-search", "llms-txt", "structured-data"],
       "homepage": "https://github.com/cucuwang/geoptimize",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "geoptimize",
-  "description": "Content-readiness lint and evidence-bounded discovery experiments",
+  "description": "Content-readiness lint with an evidence-bounded SEO experiment ledger",
   "version": "0.10.0",
   "author": {
     "name": "Te-Shu Wang"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-visible changes will be documented here. The project follows Semantic Versioning after the v0.6 evidence baseline is released.
 
+## Unreleased
+
+### Documentation
+
+- Updated current-state documentation after the verified v0.10.0 publication.
+- Aligned migration, maintainer-security, OpenSSF, Action sample, and plugin descriptions with the published release.
+
 ## 0.10.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ npx skills add cucuwang/geoptimize
 
 ## Project status
 
-Version 0.10 adds a separate, evidence-bounded SEO experiment ledger while retaining the existing readiness score and audit contracts. Release acceptance and rollback are documented in [docs/release-v0.10.md](docs/release-v0.10.md); longer-term adoption work remains in [ROADMAP.md](ROADMAP.md).
+Version 0.10.0 is published on [npm](https://www.npmjs.com/package/geoptimize) and [GitHub](https://github.com/cucuwang/geoptimize/releases/tag/v0.10.0). It adds a separate, evidence-bounded SEO experiment ledger while retaining the existing readiness score and audit contracts. Release acceptance and rollback are documented in [docs/release-v0.10.md](docs/release-v0.10.md); longer-term adoption work remains in [ROADMAP.md](ROADMAP.md).
 
 Contributions are welcome. Rule changes require an evidence note and positive/negative fixtures; see [CONTRIBUTING.md](CONTRIBUTING.md). Report vulnerabilities through the process in [SECURITY.md](SECURITY.md).
 
 ## Release integrity and security maintenance
 
-The next-release trust-hardening path is documented in [the v0.10 runbook](docs/release-v0.10.md).
+The v0.10 trust-hardening and release path is documented in [the v0.10 runbook](docs/release-v0.10.md).
 CI validates Node 22/24 tarballs, package contents and CLI/Action contracts; the
 release preparation exports SHA-256 checksums and an SPDX production-dependency SBOM.
 Repository settings and npm authorization remain explicit [maintainer gates](docs/maintainer-security-settings.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,12 +30,12 @@ The code-level gates are enforced by `npm run release:check`, `src/core/__tests_
 - automatic deployment of generated JSON-LD or crawler policy;
 - adding more AI scorers and calling their average consensus.
 
-## v0.10 — Trust hardening
+## v0.10 — Trust hardening (released)
 
 Repository preparation covers SHA-pinned Actions, minimal token permissions, a
 reusable release pipeline, OIDC preparation, tarball hashes/SPDX/attestations,
 dependency review, CodeQL, Dependabot, Scorecard and maintainer governance guidance.
-Account settings, signing identity and actual publication are separate gates;
-OpenSSF Passing is pending assessment. Package version remains 0.9.0 until release
-approval. Bundled Action runtime evaluation is tracked separately to preserve the
-package-spec contract. See [release-v0.10](docs/release-v0.10.md).
+Version 0.10.0 is published with npm OIDC provenance, an SSH-signed immutable tag,
+SHA-256 checksums, an SPDX SBOM and a GitHub artifact attestation. OpenSSF Passing
+remains pending assessment. Bundled Action runtime evaluation is tracked separately
+to preserve the package-spec contract. See [release-v0.10](docs/release-v0.10.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,8 @@ Release candidates retain the high/critical npm audit gate. Pull requests add
 dependency review; weekly Dependabot and CodeQL/Scorecard workflows support ongoing
 triage. Configuration alone does not establish a clean scan or certification.
 
-The next automated release uses npm OIDC, tarball attestations, checksums and a locked
-production SBOM. Follow [release verification](docs/release-v0.10.md) and
-[maintainer security settings](docs/maintainer-security-settings.md). Existing releases
-are not retroactively signed or attested. No long-lived npm credential is required.
+Automated releases use npm OIDC, tarball attestations, checksums and a locked
+production SBOM. Version 0.10.0 is the first release published through this path.
+Follow [release verification](docs/release-v0.10.md) and [maintainer security
+settings](docs/maintainer-security-settings.md). Earlier releases are not
+retroactively signed or attested. No long-lived npm credential is required.

--- a/docs/action-reproducibility.md
+++ b/docs/action-reproducibility.md
@@ -1,6 +1,7 @@
 # Action reproducibility decision
 
-Decision: retain the composite Action for this PR; evaluate a bundle separately in [issue #20](https://github.com/cucuwang/geoptimize/issues/20).
+The v0.10 trust-hardening review retained the composite Action and left bundle
+evaluation to [issue #20](https://github.com/cucuwang/geoptimize/issues/20).
 Both Action metadata paths now pin setup-node to an upstream commit. The default
 package-spec remains the exact published geoptimize version. No runtime behavior
 or package-spec override has been removed.
@@ -18,7 +19,7 @@ The public `package-spec` input deliberately permits test tarballs/alternate spe
 Always running a fixed bundle would ignore that input; retaining an installer fallback
 preserves much of the current surface. Puppeteer-core/browser paths, ESM dependencies,
 and dynamic imports need bundle testing even though the Action's normal scan is local.
-A broad runtime rewrite is outside this security PR.
+A broad runtime rewrite remains outside this decision.
 
 Follow-up acceptance: prototype size and cold-run timing; build the bundle twice from
 npm ci and compare hashes; preserve both metadata paths, package-spec semantics,

--- a/docs/maintainer-security-settings.md
+++ b/docs/maintainer-security-settings.md
@@ -1,8 +1,8 @@
 # Maintainer security settings
 
-Snapshot: 2026-09-09. Configuration files do not prove account settings are enabled.
-The states below were read back through the repository administration API after an
-authorized settings update. No credentials, production tags or releases were changed.
+Snapshot: 2026-09-11. Configuration files do not prove account settings are enabled.
+The states below were read back through the repository administration API, npm package
+settings and the completed v0.10 release. No credential values are stored here.
 
 ## GitHub rulesets
 
@@ -36,8 +36,9 @@ The first five job identifiers and Node matrix values are preserved. The ruleset
 the observed PR context names rather than nested `validate / …` names from the manual
 release workflow. It requires branches to be up to date and has no path filters.
 
-`protect-release-tags` (ID 22617499) is already Active for `v*.*.*`, blocking updates,
-deletion and non-fast-forward changes with no bypass actors. Preserve it and v0.9.0.
+`protect-release-tags` (ID 22617499) is Active for `v*.*.*`, blocking updates,
+deletion and non-fast-forward changes with no bypass actors. Preserve the existing
+v0.9.0 and signed v0.10.0 tags.
 
 ## Security feature settings
 
@@ -52,49 +53,50 @@ and analysis). Enable/check each independently:
 | Secret Protection → Secret scanning | Enabled |
 | Secret Protection → Push protection | Enabled |
 | Private vulnerability reporting | Enabled; the repository API returned `enabled: true` |
-| Code scanning → CodeQL | Advanced workflow passed on PR #19; first main execution remains pending |
+| Code scanning → CodeQL | Advanced workflow passes on current main and protected pull requests |
 
 The initial Dependency Review failure reported that the dependency graph was disabled.
 After enablement, the same head passed without suppressing the check or adding a PAT.
 Recheck these settings through the API and UI after ownership or security-plan changes.
 
-## Immutable releases (state not confirmed)
+## Immutable releases
 
-Settings → General → Releases → **Enable release immutability**. This applies to
-future releases, not existing v0.9.0. Save before the next publication.
-The workflow creates a draft, uploads tarball/checksums/SBOM, publishes npm, then
-publishes the draft. A finalized immutable release cannot have assets replaced;
-recover by fixing forward. Review Marketplace metadata/terms before dispatch because
-finalization must happen only after all desired assets and metadata are in place.
+Release immutability is enabled for the repository. It applies to v0.10.0 and future
+releases; historical v0.9.0 predates this setting. The workflow creates a draft,
+uploads tarball/checksums/SBOM, publishes npm, then publishes the draft. A finalized
+immutable release cannot have assets replaced; recover by fixing forward. Review all
+assets and metadata before finalization.
 
 ## npm Trusted Publisher and release gate
 
-1. npmjs.com → package **geoptimize** → Settings → Trusted Publisher → GitHub Actions.
-2. Organization/user: `cucuwang`; repository: `geoptimize`; workflow filename:
-   `release.yml`; environment: `npm-release` (exact spelling; no directory prefix).
-3. GitHub Settings → Environments → New environment `npm-release`. Restrict deployment
-   branches to `main`. Configure cucuwang as reviewer if available; allow self-review
-   for a single maintainer, otherwise the workflow cannot be approved.
-4. After all checklist items and a successful dry run, Settings → Secrets and
-   variables → Actions → Variables: set `RELEASE_ENABLED` to `true`.
-5. Do not add an npm token. The publication job uses GitHub-hosted Node 24 and checks
-   npm >=11.5.1; npm OIDC supplies short-lived authorization.
-6. Actual publication requires a separate authorization and manual dispatch with
-   `publish=true`; the default remains false. No tag-push auto-publication exists.
+Current state
+
+- npm Trusted Publisher binds `cucuwang/geoptimize`, `release.yml` and the
+  `npm-release` environment. It permits `npm publish` and `npm stage publish`.
+- The GitHub `npm-release` environment accepts only `main` through a custom branch
+  policy. Repository variable `RELEASE_ENABLED` is `true`.
+- The publication job uses GitHub-hosted Node 24 and npm OIDC. No long-lived npm token
+  is configured for this path.
+- Publication still requires a separately authorized manual dispatch with
+  `publish=true`; the default remains false. Tag pushes do not publish automatically.
+
+For future releases, preserve the exact publisher owner, repository, workflow filename
+and environment spelling. Review the signed tag, source SHA and release assets before
+dispatching publication.
 
 ## Signing identity and OpenSSF
 
-GitHub account Settings → SSH and GPG keys: register an existing approved public
-signing key (SSH key type: Signing key, or GPG public key). Configure signing locally
-following GitHub's signing guide. This PR does not create or manage keys. Verify a
-new annotated signed tag with `git tag -v` and GitHub's Verified indicator; a verified
-commit with an unsigned/lightweight tag is insufficient.
+An approved existing SSH public key is registered with GitHub as a signing key. The
+repository-local signing configuration uses that public-key path, while the private key
+remains local. GitHub verified the annotated v0.10.0 tag as valid and linked it to the
+release commit. Future release tags require the same explicit signing and readback;
+a verified commit with an unsigned or lightweight tag is insufficient.
 
 At https://www.bestpractices.dev/ sign in and register
 `https://github.com/cucuwang/geoptimize`. Complete the Passing questionnaire using
 [the gap analysis](openssf-best-practices.md). Only add its badge after the service
-actually awards Passing. Scorecard's result badge is likewise deferred until a
-successful main-branch upload is visible at scorecard.dev.
+actually awards Passing. Scorecard workflows now succeed on main; add a result badge
+only after its public score page and repository identity are read back.
 
 References: [npm OIDC](https://docs.npmjs.com/trusted-publishers/),
 [immutable releases](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes),

--- a/docs/migrating-from-aeoptimize.md
+++ b/docs/migrating-from-aeoptimize.md
@@ -2,7 +2,7 @@
 
 `geoptimize` continues the same project previously published as `aeoptimize`. Version 0.7.0 was released under the old npm name; version 0.8.0 is the first release under the new name. The GitHub repository retains the project history, issues, releases, and stars.
 
-[geoptimize on npm](https://www.npmjs.com/package/geoptimize) · [aeoptimize on npm](https://www.npmjs.com/package/aeoptimize) · [v0.7.0 release](https://github.com/cucuwang/geoptimize/releases/tag/v0.7.0) · [v0.8.0 release](https://github.com/cucuwang/geoptimize/releases/tag/v0.8.0)
+[geoptimize on npm](https://www.npmjs.com/package/geoptimize) · [aeoptimize on npm](https://www.npmjs.com/package/aeoptimize) · [v0.7.0 release](https://github.com/cucuwang/geoptimize/releases/tag/v0.7.0) · [current release](https://github.com/cucuwang/geoptimize/releases/tag/v0.10.0)
 
 ## Update an existing project
 
@@ -10,16 +10,16 @@ If the old package installed a pre-commit hook, remove that hook before uninstal
 
 ```bash
 npm uninstall aeoptimize
-npm install --save-dev geoptimize@0.8.0
+npm install --save-dev geoptimize@0.10.0
 ```
 
-| Integration | aeoptimize 0.7.0 | geoptimize 0.8.0 |
+| Integration | aeoptimize 0.7.0 | geoptimize 0.8.0 and later |
 | --- | --- | --- |
 | npm package and core imports | `aeoptimize` | `geoptimize` |
 | CLI commands | `aeoptimize`, `aeo`, `aeo-cli` | `geoptimize`, `geo`, `geo-cli` |
 | Vite import | `aeoPlugin` from `aeoptimize/vite` | `geoPlugin` from `geoptimize/vite` |
 | Next.js import | `withAeo` from `aeoptimize/next` | `withGeo` from `geoptimize/next` |
-| GitHub Action | `cucuwang/aeoptimize@v0.7.0` | `cucuwang/geoptimize@v0.8.0` |
+| GitHub Action | `cucuwang/aeoptimize@v0.7.0` | `cucuwang/geoptimize@v0.10.0` |
 | Bundled skills | `aeo-scan`, `aeo-generate`, `aeo-transform` | `geo-scan`, `geo-generate`, `geo-transform` |
 | Generated schema directory | `_aeo` | `_geo` |
 
@@ -34,7 +34,7 @@ npx --no-install geoptimize --version
 npx --no-install geoptimize audit-build ./dist --json
 ```
 
-The version should be `0.8.0`. Build the consuming project and review its output after updating Vite or Next.js imports. Deterministic scoring and audit evidence contracts are preserved across the rename.
+The installed version should be `0.10.0`. Build the consuming project and review its output after updating Vite or Next.js imports. Deterministic scoring and audit evidence contracts are preserved across the rename.
 
 ## Package history and download counts
 

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -1,6 +1,6 @@
 # OpenSSF Best Practices: Passing gap analysis
 
-Assessment date: 2026-09-09. This is evidence preparation, not a certification or
+Assessment date: 2026-09-09; release evidence reviewed 2026-09-11. This is evidence preparation, not a certification or
 completed questionnaire. [Official Passing criteria](https://www.bestpractices.dev/en/criteria/0?details=true&rationale=true)
 remain authoritative; review every applicable MUST/MUST NOT and justify SHOULD items
 when registering. Silver and Gold are outside scope.
@@ -21,13 +21,13 @@ These are observable artifacts, not a declaration that every criterion in an are
 is met. Public source availability does not establish license compatibility of every
 transitive dependency or the maintainer's historical response performance.
 
-## Repository changes required
+## Repository and evidence status
 
 | Work | Status / evidence needed |
 | --- | --- |
-| Static analysis for application and workflow sources | CodeQL passed on PR #19; first main run and ongoing finding triage remain |
+| Static analysis for application and workflow sources | CodeQL and Scorecard workflows pass on current main; ongoing finding triage remains |
 | Automated dependency review and updates | Dependency Review passed; Dependabot alerts, security updates and weekly version updates are enabled |
-| Verifiable release integrity | OIDC workflow, SBOM, checksums and attestation prepared; next authorized release supplies public evidence |
+| Verifiable release integrity | v0.10.0 is public with npm OIDC provenance, an SSH-signed tag, checksums, an SPDX SBOM and a GitHub attestation; future releases must repeat the same gates |
 | Document operational trust boundaries | Release/settings/Action decision documents added |
 | Release notes for security fixes | Changelog process exists; describe actual fixes and identifiers when applicable |
 

--- a/docs/release-v0.10.md
+++ b/docs/release-v0.10.md
@@ -1,9 +1,11 @@
 # v0.10 trust-hardening release runbook
 
-Status: release candidate preparation; package version 0.10.0 is under review.
-Nothing in this document asserts that 0.10.0 has been published. This release
-adds the `geo seo` CLI, API, data contract, and skill while preserving the
-readiness score, existing audit JSON, and composite Action scoring contracts.
+Status: published and verified on 2026-09-11.
+Version 0.10.0 was published from commit
+`01ac0f19e2a7f8f8854b3304ecd0193a6a9d2b63` with an SSH-signed tag, npm OIDC
+provenance and a GitHub artifact attestation. This release adds the `geo seo`
+CLI, API, data contract, and skill while preserving the readiness score,
+existing audit JSON, and composite Action scoring contracts.
 
 ## Candidate and dry run
 
@@ -46,31 +48,48 @@ All CI gates run and release-assets is retained; no signing, OIDC publication,
 attestation or GitHub Release writes occur. A successful dry run proves packaging,
 not external npm authorization or immutable-release settings.
 
-## Authorized next release
+## Executed release procedure
 
-1. Complete [maintainer settings](maintainer-security-settings.md), including npm
-   environment binding, main required checks, immutable releases and signing identity.
-2. Review the version-bump PR that updates package/lock, CLI and plugin metadata,
-   both Action defaults, sample pins, hard-coded CI tarball fixtures, changelog,
-   the SEO workflow, and release-contract expectations. Run all gates. Preserve v0.9.0.
-3. Merge the approved release commit, fetch origin/main, and ensure it is still main's
-   exact HEAD. With explicit release authorization, create an annotated signed tag
-   (`git tag -s v0.10.0 <commit> -m 'geoptimize 0.10.0'`) and push only that tag.
-   Verify it locally and on GitHub. Do not create or move tags as part of hardening.
-4. Dispatch Release on main with tag `v0.10.0`, publish true. Confirm the run commit
-   matches the tag. Approve npm-release after reviewing the CI results and artifacts.
-5. Preflight rejects unsigned/lightweight tags, wrong SHA/version/repository, dirty
-   source, changed main HEAD, corrupted artifacts and already-published npm versions.
-6. Attest the tarball; create a draft with all assets; publish that exact tarball with
-   npm OIDC/provenance; finalize the draft; run the existing public readback verifier.
+1. Maintainer settings were completed, including the npm environment binding, main
+   required checks, immutable releases and an approved signing identity.
+2. The version update aligned package/lock, CLI and plugin metadata, both Action
+   defaults, sample pins, CI tarball fixtures, changelog, the SEO workflow and release
+   contract expectations. All release gates passed before publication.
+3. The approved release commit was merged and re-fetched as the exact main HEAD. The
+   annotated SSH-signed `v0.10.0` tag was created for that commit and verified on GitHub.
+4. Release was dispatched from main with tag `v0.10.0` and `publish=true`. The
+   npm-release environment admitted the job after the source and artifact checks passed.
+5. Preflight rejected wrong or previously published versions and required the signed
+   tag, exact main SHA, expected repository and byte-identical candidate.
+6. The workflow attested the tarball, staged a draft with all assets, published the
+   verified tarball through npm OIDC, and finalized the GitHub Release.
 
 The GitHub Release uses [public release notes](release-notes-v0.10.md). Keep setup,
 approval and recovery instructions in this runbook rather than publishing them as the
 release description.
 
-Expected assets: `geoptimize-0.10.0.tgz`, `geoptimize-0.10.0.spdx.json`, `SHA256SUMS`.
+Published assets: `geoptimize-0.10.0.tgz`, `geoptimize-0.10.0.spdx.json`, `SHA256SUMS`.
 The Actions artifact also retains candidate.json. Filenames are version-derived.
 Checksums are calculated from actual artifact bytes, including the SBOM.
+
+## Publication receipt
+
+| Evidence | Verified value |
+| --- | --- |
+| Release commit | `01ac0f19e2a7f8f8854b3304ecd0193a6a9d2b63` |
+| Signed tag | `v0.10.0`, GitHub verification `valid` |
+| npm package | `geoptimize@0.10.0`, dist-tag `latest` |
+| Tarball SHA-256 | `dbe2d0702020875a1cbef60a52c82cf3415c5f75ee2b44ff88dacb021e023d7c` |
+| GitHub Release | [geoptimize 0.10.0](https://github.com/cucuwang/geoptimize/releases/tag/v0.10.0) |
+| Publication workflow | [Release run 34567150571](https://github.com/cucuwang/geoptimize/actions/runs/34567150571) |
+| Provenance signer | `.github/workflows/release.yml` on `refs/heads/main` |
+
+The npm publish command succeeded at 05:46:10Z and reported that registry processing
+could take a few minutes. The same workflow ran its public verifier one second later,
+before npm exposed the new packument, so the run retained a failed final check. npm
+published the version at 05:49:19Z. After propagation, the same verifier passed the npm
+version, repository identity, tarball hash, all three CLI aliases, tag target and
+non-draft GitHub Release. Publication must not be rerun for this immutable version.
 
 ## What the evidence establishes
 

--- a/examples/github-action-sample/README.md
+++ b/examples/github-action-sample/README.md
@@ -6,4 +6,5 @@ This directory is a copyable end-to-end sample for the v0.6 Action contract.
 - `site/index.html` is a deterministic public input.
 - The Action is advisory by default. The sample does not block a pull request on an unreviewed score threshold.
 
-The workflow becomes reproducible only after both `geoptimize@0.10.0` exists on npm and the immutable `v0.10.0` Git tag points to the matching release commit. Until both artifacts exist, use the local CLI or the release-candidate package during controlled verification.
+The workflow pins the published `geoptimize@0.10.0` package through the immutable
+`v0.10.0` Git tag. Both artifacts were verified against the same release commit.

--- a/src/core/__tests__/evidence-boundaries.test.ts
+++ b/src/core/__tests__/evidence-boundaries.test.ts
@@ -119,6 +119,37 @@ describe('public metadata', () => {
     expect(compatibilityAction).toContain(`default: 'geoptimize@${packageJson.version}'`);
     expect(compatibilityAction).toContain("default: 'false'");
     expect(pluginJson.commands).toContain('./skills/seo-experiment-ledger/SKILL.md');
+    expect(pluginJson.description).toBe(
+      'Content-readiness lint with an evidence-bounded SEO experiment ledger',
+    );
+    expect(marketplaceJson.metadata.description).toBe(pluginJson.description);
+    expect(marketplaceJson.plugins[0].description).toContain('SEO experiments');
+  });
+
+  it('keeps current user documentation aligned with the published version', async () => {
+    const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+    const version = packageJson.version as string;
+    const [readme, roadmap, security, migration, sample, settings, openSsf] = await Promise.all([
+      readFile(join(root, 'README.md'), 'utf8'),
+      readFile(join(root, 'ROADMAP.md'), 'utf8'),
+      readFile(join(root, 'SECURITY.md'), 'utf8'),
+      readFile(join(root, 'docs', 'migrating-from-aeoptimize.md'), 'utf8'),
+      readFile(join(root, 'examples', 'github-action-sample', 'README.md'), 'utf8'),
+      readFile(join(root, 'docs', 'maintainer-security-settings.md'), 'utf8'),
+      readFile(join(root, 'docs', 'openssf-best-practices.md'), 'utf8'),
+    ]);
+
+    expect(readme).toContain(`Version ${version} is published`);
+    expect(roadmap).toContain(`Version ${version} is published`);
+    expect(roadmap).not.toContain('Package version remains 0.9.0');
+    expect(security).toContain(`Version ${version} is the first release`);
+    expect(migration).toContain(`geoptimize@${version}`);
+    expect(migration).toContain(`installed version should be \`${version}\``);
+    expect(sample).toContain(`published \`geoptimize@${version}\` package`);
+    expect(sample).not.toContain('Until both artifacts exist');
+    expect(settings).toContain('Release immutability is enabled');
+    expect(settings).toContain('npm Trusted Publisher binds');
+    expect(openSsf).toContain(`${version} is public with npm OIDC provenance`);
   });
 
   it('keeps npm publisher metadata normalized and exposes every CLI alias', async () => {

--- a/src/core/__tests__/release-contract.test.ts
+++ b/src/core/__tests__/release-contract.test.ts
@@ -217,6 +217,8 @@ describe('v0.6 JSON automation contract', () => {
     expect(workflow).not.toContain('--notes-file docs/release-v0.10.md');
     expect(releaseNotes).toContain('# geoptimize 0.10.0');
     expect(releaseNotes).not.toContain('repository preparation');
-    expect(runbook).toContain('Status: release candidate preparation');
+    expect(runbook).toContain('Status: published and verified on 2026-09-11.');
+    expect(runbook).toContain('## Publication receipt');
+    expect(runbook).not.toContain('release candidate preparation');
   });
 });


### PR DESCRIPTION
## Summary

Updates current documentation after the verified v0.10.0 publication, fixes the migration guide and maintainer state, and aligns plugin descriptions with the SEO experiment ledger. Historical release records remain unchanged.

## Verification

- `npm run release:check`
- 252 tests passed
- 37 Markdown files checked with no missing relative links
- eight localized README contracts checked

## For reviewers

Please verify that the publication receipt distinguishes the successful release from the registry-propagation timing failure in the original workflow run.